### PR TITLE
Master

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,7 @@
 *.dtd text eol=lf
 *.esp text eol=lf
 *.ecma text eol=lf
-*.hbrs text eol=lf
+*.hbs text eol=lf
 *.htm text eol=lf
 *.html text eol=lf
 *.java text eol=lf

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.ssl.conf.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.ssl.conf.hbs
@@ -21,7 +21,7 @@
 {{~#if dispatcher.enforceSsl}}
   # Enable HSTS if SSL is enforced
   <IfModule mod_headers.c>
-    Header always set Strict-Transport-Security "max-age=7884000"
+    Header always set Strict-Transport-Security "max-age=31536000"
   </IfModule>
 {{/if}}
 


### PR DESCRIPTION
Set the HTTP Strict Transport Security to 31536000 seconds (one year) as recommended by qualys https://blog.qualys.com/securitylabs/2016/03/28/the-importance-of-a-proper-http-strict-transport-security-implementation-on-your-web-server