### PR TITLE
Apache 2.4 compatibility

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -33,6 +33,21 @@
       <action type="update" dev="twolfart">
         VHost templates: Remove document root, not required because dispatcher handles all requests.
       </action>
+      <action type="add" dev="trichter">
+        Apache 2.4 compatibility: Add conditional statements for access control to enable Apache 2.4 compatibility without access_compat module.
+      </action>
+      <action type="add" dev="trichter">
+        Apache 2.4 compatibility: Add dispatcher.allowAdminAccessFromHost option for host based access control
+      </action>
+      <action type="add" dev="trichter">
+        Apache 2.4 compatibility: Add dispatcher.allowFlushFromHost option for host based access control
+      </action>
+      <action type="update" dev="trichter">
+        Apache 2.4 compatibility: Change dispatcher.allowFlushFrom and dispatcher.allowAdminAccessFrom based rules to handle ip addresses only
+      </action>
+      <action type="update" dev="trichter">
+        Apache 2.4 compatibility: Updated roles and examples to reflect new options dispatcher.allowFlushFromHost and dispatcher.allowAdminAccessFromHost
+      </action>
     </release>
 
     <release version="0.7.0" date="2016-09-21">

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-author.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-author.yaml
@@ -45,7 +45,9 @@ config:
     forwardClientHeaders:
     - "*"
     #allowAdminAccessFrom: 10.0.0.0/255.0.0.0
-    #allowFlushFrom: 127.0.0.1 localhost
+    #allowAdminAccessFromHost: www.example.org
+    #allowFlushFrom: 127.0.0.1
+    #allowFlushFromHost: localhost
     cacheDamAssets: false
     sslCertificateFile: /path/to/sslCertificateFile
     sslCertificateKeyFile: /path/to/sslCertificateKeyFile

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-publish.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-publish.yaml
@@ -50,7 +50,8 @@ config:
       host: localhost
       port: 4502
     #statFilesLevel: 3
-    #allowFlushFrom: 127.0.0.1 localhost
+    #allowFlushFrom: 127.0.0.1
+    #allowFlushFromHost: localhost
     rootRedirectHttpStatus: 301
     forwardClientHeaders:
     - "*"

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.partials.hbs
@@ -17,7 +17,7 @@
 {{~#block "rewriteEnforcePrimaryHostname"}}
   # Make sure primary hostname is always used
   RewriteEngine On
-  RewriteCond %{HTTP_HOST} !^{{regexQuote cmsAuthorHostname}}$ [NC] 
+  RewriteCond %{HTTP_HOST} !^{{regexQuote cmsAuthorHostname}}$ [NC]
   RewriteRule ^(.*)$ http://{{cmsAuthorHostname}}$1 [R=301,L]
 {{/block}}
 
@@ -30,8 +30,6 @@
       # enable dispatcher for ALL requests.
       SetHandler dispatcher-handler
     </IfModule>
-    Options FollowSymLinks
-    AllowOverride None
   </Location>
 {{/block}}
 
@@ -47,39 +45,77 @@
 {{~#block "accessRestrictions"}}
   # Deny external access to system console, but allow access to logout
   <LocationMatch "^/admin/.*$">
-    Order deny,allow
-    Deny from all
+    <IfVersion < 2.4>
+      Order deny,allow
+      Deny from all
 {{~#if dispatcher.allowAdminAccessFrom}}
-    Allow from {{dispatcher.allowAdminAccessFrom}}
+      Allow from {{dispatcher.allowAdminAccessFrom}}
 {{~/if}}
+    </IfVersion>
+    <IfVersion >= 2.4>
+      Require all denied
+{{~#if dispatcher.allowAdminAccessFrom}}
+      Require host {{dispatcher.allowAdminAccessFrom}}
+{{~/if}}
+    </IfVersion>
   </LocationMatch>
   <LocationMatch "^/system/.*$">
-    Order deny,allow
-    Deny from all
+    <IfVersion < 2.4>
+      Order deny,allow
+      Deny from all
 {{~#if dispatcher.allowAdminAccessFrom}}
-    Allow from {{dispatcher.allowAdminAccessFrom}}
+      Allow from {{dispatcher.allowAdminAccessFrom}}
 {{~/if}}
+    </IfVersion>
+    <IfVersion >= 2.4>
+      Require all denied
+{{~#if dispatcher.allowAdminAccessFrom}}
+      Require host {{dispatcher.allowAdminAccessFrom}}
+{{~/if}}
+    </IfVersion>
   </LocationMatch>
   <LocationMatch "^/system/sling/logout.*$">
-    Order deny,allow
-    Allow from all
+    <IfVersion < 2.4>
+      Order deny,allow
+      Allow from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+      Require all granted
+    </IfVersion>
   </LocationMatch>
 
   # Deny external access to CRX web application
   <LocationMatch "^/crx.*$">
-    Order deny,allow
-    Deny from all
+    <IfVersion < 2.4>
+      Order deny,allow
+      Deny from all
 {{~#if dispatcher.allowAdminAccessFrom}}
-    Allow from {{dispatcher.allowAdminAccessFrom}}
+      Allow from {{dispatcher.allowAdminAccessFrom}}
 {{~/if}}
+    </IfVersion>
+    <IfVersion >= 2.4>
+      Require all denied
+{{~#if dispatcher.allowAdminAccessFrom}}
+      Require host {{dispatcher.allowAdminAccessFrom}}
+{{~/if}}
+    </IfVersion>
   </LocationMatch>
 
   # Allow dispatcher flushing only from defined hosts
   <Location "/dispatcher">
-    Order Deny,Allow
-    Deny from all
-  {{~#if dispatcher.allowFlushFrom}}
-    Allow from {{dispatcher.allowFlushFrom}}
-  {{~/if}}
+    <IfVersion < 2.4>
+      Order Deny,Allow
+      Deny from all
+{{~#if dispatcher.allowFlushFrom}}
+      Allow from {{dispatcher.allowFlushFrom}}
+{{~/if}}
+    </IfVersion>
+    <IfVersion >= 2.4>
+      Require all denied
+{{~#if dispatcher.allowFlushFrom}}
+      Require host {{dispatcher.allowFlushFrom}}
+{{~/if}}
+    </IfVersion>
+
   </Location>
 {{/block}}

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.partials.hbs
@@ -51,11 +51,17 @@
 {{~#if dispatcher.allowAdminAccessFrom}}
       Allow from {{dispatcher.allowAdminAccessFrom}}
 {{~/if}}
+{{~#if dispatcher.allowAdminAccessFromHost}}
+      Allow from {{dispatcher.allowAdminAccessFromHost}}
+{{~/if}}
     </IfVersion>
     <IfVersion >= 2.4>
       Require all denied
 {{~#if dispatcher.allowAdminAccessFrom}}
-      Require host {{dispatcher.allowAdminAccessFrom}}
+      Require ip {{dispatcher.allowAdminAccessFrom}}
+{{~/if}}
+{{~#if dispatcher.allowAdminAccessFromHost}}
+      Require host {{dispatcher.allowAdminAccessFromHost}}
 {{~/if}}
     </IfVersion>
   </LocationMatch>
@@ -66,11 +72,17 @@
 {{~#if dispatcher.allowAdminAccessFrom}}
       Allow from {{dispatcher.allowAdminAccessFrom}}
 {{~/if}}
+{{~#if dispatcher.allowAdminAccessFromHost}}
+      Allow from {{dispatcher.allowAdminAccessFromHost}}
+{{~/if}}
     </IfVersion>
     <IfVersion >= 2.4>
       Require all denied
 {{~#if dispatcher.allowAdminAccessFrom}}
-      Require host {{dispatcher.allowAdminAccessFrom}}
+      Require ip {{dispatcher.allowAdminAccessFrom}}
+{{~/if}}
+{{~#if dispatcher.allowAdminAccessFromHost}}
+      Require host {{dispatcher.allowAdminAccessFromHost}}
 {{~/if}}
     </IfVersion>
   </LocationMatch>
@@ -92,11 +104,17 @@
 {{~#if dispatcher.allowAdminAccessFrom}}
       Allow from {{dispatcher.allowAdminAccessFrom}}
 {{~/if}}
+{{~#if dispatcher.allowAdminAccessFromHost}}
+      Allow from {{dispatcher.allowAdminAccessFromHost}}
+{{~/if}}
     </IfVersion>
     <IfVersion >= 2.4>
       Require all denied
 {{~#if dispatcher.allowAdminAccessFrom}}
-      Require host {{dispatcher.allowAdminAccessFrom}}
+      Require ip {{dispatcher.allowAdminAccessFrom}}
+{{~/if}}
+{{~#if dispatcher.allowAdminAccessFromHost}}
+      Require host {{dispatcher.allowAdminAccessFromHost}}
 {{~/if}}
     </IfVersion>
   </LocationMatch>
@@ -109,11 +127,17 @@
 {{~#if dispatcher.allowFlushFrom}}
       Allow from {{dispatcher.allowFlushFrom}}
 {{~/if}}
+{{~#if dispatcher.allowFlushFromHost}}
+      Allow from {{dispatcher.allowFlushFromHost}}
+{{~/if}}
     </IfVersion>
     <IfVersion >= 2.4>
       Require all denied
 {{~#if dispatcher.allowFlushFrom}}
-      Require host {{dispatcher.allowFlushFrom}}
+      Require ip {{dispatcher.allowFlushFrom}}
+{{~/if}}
+{{~#if dispatcher.allowFlushFrom}}
+      Require host {{dispatcher.allowFlushFromHost}}
 {{~/if}}
     </IfVersion>
 

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/_vhost_publish_shared_include.conf.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/_vhost_publish_shared_include.conf.hbs
@@ -132,11 +132,17 @@ Header set Cache-Control "public, must-revalidate"
 {{~#if dispatcher.allowFlushFrom}}
     Allow from {{dispatcher.allowFlushFrom}}
 {{~/if}}
+{{~#if dispatcher.allowFlushFromHost}}
+    Allow from {{dispatcher.allowFlushFromHost}}
+{{~/if}}
   </IfVersion>
   <IfVersion >= 2.4>
     Require all denied
 {{~#if dispatcher.allowFlushFrom}}
-    Require host {{dispatcher.allowFlushFrom}}
+    Require ip {{dispatcher.allowFlushFrom}}
+{{~/if}}
+{{~#if dispatcher.allowFlushFromHost}}
+    Require host {{dispatcher.allowFlushFromHost}}
 {{~/if}}
   </IfVersion>
 </Location>

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/_vhost_publish_shared_include.conf.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/_vhost_publish_shared_include.conf.hbs
@@ -18,8 +18,6 @@ RewriteEngine On
     # enable dispatcher for ALL requests.
     SetHandler dispatcher-handler
   </IfModule>
-  Options FollowSymLinks
-  AllowOverride None
 </Location>
 
 
@@ -44,45 +42,103 @@ Header set Cache-Control "public, must-revalidate"
 #### Deny access to sensitive areas ####
 
 <Location "/admin">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </Location>
 <Location "/apps">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </Location>
 <Location "/bin">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </Location>
 <Location "/crx">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </Location>
 <Location "/etc">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </Location>
 <Location "/home">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </Location>
 <Location "/libs">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </Location>
 <Location "/system/console">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </Location>
 <Location "/var">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </Location>
 
 # Allow access to clientlibs
 <Location "/etc/clientlibs">
-  Allow from all
+  <IfVersion < 2.4>
+    Allow from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all granted
+  </IfVersion>
 </Location>
 
 # Allow dispatcher flushing only from defined hosts
 <Location "/dispatcher">
-  Order Deny,Allow
-  Deny from all
+  <IfVersion < 2.4>
+    Order Deny,Allow
+    Deny from all
 {{~#if dispatcher.allowFlushFrom}}
-  Allow from {{dispatcher.allowFlushFrom}}
+    Allow from {{dispatcher.allowFlushFrom}}
 {{~/if}}
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+{{~#if dispatcher.allowFlushFrom}}
+    Require host {{dispatcher.allowFlushFrom}}
+{{~/if}}
+  </IfVersion>
 </Location>
 
 
@@ -90,40 +146,80 @@ Header set Cache-Control "public, must-revalidate"
 
 #match *.infinity.json
 <LocationMatch "^/.*\.infinity\.json.*$">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </LocationMatch>
 
 # match *.-1.json and similar
 <LocationMatch "^/.*\.-[0-9]+\.json.*$">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </LocationMatch>
 
 # match *.tidy.json
 <LocationMatch "^/.*\.tidy\.json.*$">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </LocationMatch>
 
 # match *.query.json
 <LocationMatch "^/.*\.query\.json.*$">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </LocationMatch>
 
 # match sysview.xml
 <LocationMatch "^/.*\.sysview\.xml.*$">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </LocationMatch>
 
 # match docview.json/xml
 <LocationMatch "^/.*\.docview\.(json|xml).*$">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </LocationMatch>
 
 # match feed/feedentry.*
 <LocationMatch "^/.*\.feed(entry)?\.*.*$">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </LocationMatch>
 
 # match form.*
 <LocationMatch "^/.*\.form\.*.*$">
-  Deny from all
+  <IfVersion < 2.4>
+    Deny from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all denied
+  </IfVersion>
 </LocationMatch>

--- a/example/src/main/environments/test.yaml
+++ b/example/src/main/environments/test.yaml
@@ -63,7 +63,7 @@ config:
   dispatcher:
     moduleFile: /usr/lib/apache2/modules/mod_dispatcher.so
     allowFlushFrom: 127.0.0.1
-    allowFlushFromHost localhost
+    allowFlushFromHost: localhost
     sslCertificateFile: /etc/ssl/certs/sample.crt
     sslCertificateKeyFile: /etc/ssl/private/sample.key
     sslCACertificatePath: /etc/ssl/certs

--- a/example/src/main/environments/test.yaml
+++ b/example/src/main/environments/test.yaml
@@ -36,6 +36,7 @@ nodes:
           host: localhost
           port: 4502
         allowAdminAccessFrom: 10.0.0.0/255.0.0.0
+        allowAdminAccessFromHost: www.example.org
   - role: aem-dispatcher-publish
     variant: no-ssl+ssl
     config:
@@ -46,6 +47,7 @@ nodes:
           host: localhost
           port: 4503
         allowAdminAccessFrom: 10.0.0.0/255.0.0.0
+        allowAdminAccessFromHost: www.example.org
         forwardClientHeaders:
         - referer
         - content-type
@@ -60,7 +62,8 @@ config:
   jvm.path: "/usr/lib/jvm/jdk-8-oracle-x64"
   dispatcher:
     moduleFile: /usr/lib/apache2/modules/mod_dispatcher.so
-    allowFlushFrom: 127.0.0.1 localhost
+    allowFlushFrom: 127.0.0.1
+    allowFlushFromHost localhost
     sslCertificateFile: /etc/ssl/certs/sample.crt
     sslCertificateKeyFile: /etc/ssl/private/sample.key
     sslCACertificatePath: /etc/ssl/certs


### PR DESCRIPTION
This PR adds Apache 2.4 compatibility with conditional statements.
To handle ip address and host based access control rules in Apache 2.4 the options

- dispatcher.allowFlushFromHost
- dispatcher.allowAdminAccessFromHost

were introduced for handling host based rules.

The existing options

- dispatcher.allowFlushFrom
- dispatcher.allowAdminAccessFrom

are used for ip based access control options.