### PR TITLE
Make each role explicitly activate all httpd modules it depends on.

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="0.8.2" date="not released">
+      <action type="update" dev="mwehner">
+        Role aem-dispatcher-*: Make each role explicitly activate all httpd modules it depends on.
+      </action>
       <action type="fix" dev="sseifert">
         Role aem-cms: Fix PID of Sling DavEx servlet.
       </action>

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-author.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-author.yaml
@@ -6,7 +6,17 @@ templateDir: aem-dispatcher/author
 variants:
 - variant: no-ssl
 - variant: ssl
+  config:
+    httpd:
+      modules:
+      - _merge_
+      - ssl
 - variant: no-ssl+ssl
+  config:
+    httpd:
+      modules:
+      - _merge_
+      - ssl
 
 files:
 
@@ -53,3 +63,9 @@ config:
     sslCertificateKeyFile: /path/to/sslCertificateKeyFile
     #sslCACertificatePath: /path/to/sslCACertificates
     #sslCACertificateFile: /path/to/sslCACertificateFile
+
+  httpd:
+    # Modules to be activated in httpd as they are used in the templates. Use names that can be used with a2enmod.
+    modules:
+    - rewrite
+    - headers

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-common.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-common.yaml
@@ -28,7 +28,7 @@ config:
     moduleFile: modules/mod_dispatcher.so
 
   httpd:
-    # Default modules names to be included in Apache httpd. Use names that can be used with a2enmod.
+    # Modules to be activated in httpd as they are used in the templates. Use names that can be used with a2enmod.
     modules:
-    - rewrite
+    - dispatcher
     - headers

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-publish.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-publish.yaml
@@ -6,7 +6,17 @@ templateDir: aem-dispatcher/publish
 variants:
 - variant: no-ssl
 - variant: ssl
+  config:
+    httpd:
+      modules:
+      - _merge_
+      - ssl
 - variant: no-ssl+ssl
+  config:
+    httpd:
+      modules:
+      - _merge_
+      - ssl
 
 files:
 
@@ -70,7 +80,11 @@ config:
       #- www.host1.com
       #- www.host2.com
 
-
+  httpd:
+    # Modules to be activated in httpd as they are used in the templates. Use names that can be used with a2enmod.
+    modules:
+    - rewrite
+    - headers
 
 # Example tenant configuration. Tenant name = primary host name/server name
 #config:


### PR DESCRIPTION
As discussed: All roles should explicitly list all httpd modules they depend on for their configuration files, even if that means that the same module is activated multiple times.