### PR TITLE
Properly ignore IntelliJ *.iml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ npm-debug.log
 .pmd
 .checkstyle
 .idea
-.iml
+*.iml
 .DS_Store
 .rubygems
 .sass-cache


### PR DESCRIPTION
Currently IntelliJ *.iml files are not ignored by Git