### PR TITLE
Start AEM with -nofork option

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -25,6 +25,9 @@
 
     <release version="0.8.2" date="not released">
       <action type="update" dev="mwehner">
+        Role aem-cms: Start AEM with -nofork option.
+      </action>
+      <action type="update" dev="mwehner">
         Role aem-dispatcher-*: Make each role explicitly activate all httpd modules it depends on.
       </action>
       <action type="fix" dev="sseifert">

--- a/conga-aem-definitions/src/main/templates/aem-cms/start.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-cms/start.hbs
@@ -138,7 +138,7 @@ if [ $CQ_USE_JAAS ]; then
     CQ_JVM_OPTS="${CQ_JVM_OPTS} -Djava.security.auth.login.config=${CQ_JAAS_CONFIG}"
 fi
 START_OPTS="${START_OPTS} -Dsling.properties=conf/sling.properties"
-
+START_OPTS="${START_OPTS} -nofork"
 (
   (
     java $CQ_JVM_OPTS -jar $CURR_DIR/$CQ_JARFILE $START_OPTS &


### PR DESCRIPTION
I didn't make it optional since you never want AEM to fork beyond the Quickstart double-click usecase.