### PR TITLE
Improve support for error handlers

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -36,6 +36,9 @@
       <action type="update" dev="sseifert">
         Role aem-cms: Remove 'Create web enabled video formats' step from minimal DAM Update Asset workflow.
       </action>
+      <action type="add" dev="twolfart">
+        Sling Mapping: ease handling for resolution of non-matching requests
+      </action>
     </release>
 
     <release version="0.9.0" date="2017-04-07">

--- a/conga-aem-definitions/src/main/templates/aem-cms/aem-cms-publish-slingmapping.json.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-cms/aem-cms-publish-slingmapping.json.hbs
@@ -7,13 +7,13 @@
 {{#eachIf tenants "config.slingMappingPath"}},
     "{{this.tenant}}": {
       "jcr:primaryType": "sling:Mapping",
-      "sling:internalRedirect": ["{{this.config.slingMappingPath}}","/"],
+      "sling:internalRedirect": ["/","{{this.config.slingMappingPath}}"],
       "sling:match": "^(?!/etc.clientlibs).*$"
     }
   {{~#each this.config.serverAliasNames}},
     "{{this}}": {
       "jcr:primaryType": "sling:Mapping",
-      "sling:internalRedirect": ["{{../this.config.slingMappingPath}}","/"],
+      "sling:internalRedirect": ["/","{{../this.config.slingMappingPath}}"],
       "sling:match": "^(?!/etc.clientlibs).*$"
     }
   {{/each ~}}
@@ -28,20 +28,20 @@
   {{~#if this.config.serverNameSsl}}
     "{{this.config.serverNameSsl}}": {
       "jcr:primaryType": "sling:Mapping",
-      "sling:internalRedirect": ["{{this.config.slingMappingPath}}","/"],
+      "sling:internalRedirect": ["/","{{this.config.slingMappingPath}}"],
       "sling:match": "^(?!/etc.clientlibs).*$"
     }
   {{~ else ~}}
     "{{this.tenant}}": {
       "jcr:primaryType": "sling:Mapping",
-      "sling:internalRedirect": ["{{this.config.slingMappingPath}}","/"],
+      "sling:internalRedirect": ["/","{{this.config.slingMappingPath}}"],
       "sling:match": "^(?!/etc.clientlibs).*$"
     }
   {{/if ~}}
   {{~#each this.config.serverAliasNames}},
     "{{this}}": {
       "jcr:primaryType": "sling:Mapping",
-      "sling:internalRedirect": ["{{../this.config.slingMappingPath}}","/"],
+      "sling:internalRedirect": ["/","{{../this.config.slingMappingPath}}"],
       "sling:match": "^(?!/etc.clientlibs).*$"
     }
   {{/each ~}}


### PR DESCRIPTION
Using "/" as the first search path improves the order of "realPathList" if the resource resolution has no match.

If no resource from the complete list of possible matches can be mapped to content (e.g. on a 404), the first generated resource path is returned. This currently adds "{slingMappingPath}" to the path. Assuming Dispatcher provides an non-shortened path, this path is better _not_ changed, or handlers working with it will have to cope with a path containing added path segments.

Relevant code in Sling: https://github.com/apache/sling/blob/6ec4eef74b1120d1eb15fe50f4e45497151b46e6/bundles/resourceresolver/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java#L370
