### PR TITLE
Exclude the dispatcher invalidation URL from rewriting.

### DIFF
--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.partials.hbs
@@ -17,6 +17,8 @@
 {{~#block "rewriteEnforcePrimaryHostname"}}
   # Make sure primary hostname is always used
   RewriteEngine On
+  # Don't rewrite the dispatcher invalidation URL
+  RewriteCond %{REQUEST_URI} !^/dispatcher/invalidate.cache
   RewriteCond %{HTTP_HOST} !^{{regexQuote cmsAuthorHostname}}$ [NC]
   RewriteRule ^(.*)$ http://{{cmsAuthorHostname}}$1 [R=301,L]
 {{/block}}

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.ssl.conf.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.ssl.conf.hbs
@@ -9,6 +9,8 @@
 {{~#partial "rewriteEnforcePrimaryHostname"}}
   # Make sure primary hostname is always used
   RewriteEngine On
+  # Don't rewrite the dispatcher invalidation URL
+  RewriteCond %{REQUEST_URI} !^/dispatcher/invalidate.cache
   RewriteCond %{HTTP_HOST} !^{{regexQuote cmsAuthorHostnameSsl}}$ [NC] 
   RewriteRule ^(.*)$ https://{{cmsAuthorHostnameSsl}}$1 [R=301,L]
 {{/partial}}

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/_vhost_publish_shared_include.conf.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/_vhost_publish_shared_include.conf.hbs
@@ -8,8 +8,6 @@ TraceEnable Off
 
 # Enable rewrite engine
 RewriteEngine On
-# Don't rewrite the dispatcher invalidation URL
-RewriteCond %{REQUEST_URI} !^/dispatcher/invalidate.cache
 
 #### Enable AEM dispatcher module ####
 

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/_vhost_publish_shared_include.conf.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/_vhost_publish_shared_include.conf.hbs
@@ -8,7 +8,8 @@ TraceEnable Off
 
 # Enable rewrite engine
 RewriteEngine On
-
+# Don't rewrite the dispatcher invalidation URL
+RewriteCond %{REQUEST_URI} !^/dispatcher/invalidate.cache
 
 #### Enable AEM dispatcher module ####
 

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.partials.hbs
@@ -30,6 +30,8 @@
 
 
 {{~#block "rewriteEnforcePrimaryHostname"}}
+  # Don't rewrite the dispatcher invalidation URL
+  RewriteCond %{REQUEST_URI} !^/dispatcher/invalidate.cache
   # Make sure primary hostname is always used
   RewriteCond %{HTTP_HOST} !^{{regexQuote tenant}}$ [NC] 
   RewriteRule ^(.*)$ http://{{tenant}}$1 [R=301,L]
@@ -69,6 +71,8 @@
 
 {{~#block "rewriteSlingShortUrlMapping"}}
 {{~#if slingMappingPath}}
+  # Don't rewrite the dispatcher invalidation URL
+  RewriteCond %{REQUEST_URI} !^/dispatcher/invalidate.cache
   # Short URL configuration according to http://www.cognifide.com/blogs/cq/multidomain-cq-mappings-and-apache-configuration/
   RewriteCond %{REQUEST_URI} !^/apps
   RewriteCond %{REQUEST_URI} !^/bin

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.ssl.conf.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.ssl.conf.hbs
@@ -9,6 +9,8 @@
 {{/partial ~}}
 
 {{#partial "rewriteEnforcePrimaryHostname"}}
+  # Don't rewrite the dispatcher invalidation URL
+  RewriteCond %{REQUEST_URI} !^/dispatcher/invalidate.cache
   # Make sure primary hostname is always used
   RewriteCond %{HTTP_HOST} !^{{#if serverNameSsl}}{{regexQuote serverNameSsl}}{{else}}{{regexQuote tenant}}{{/if}}$ [NC] 
   RewriteRule ^(.*)$ https://{{#if serverNameSsl}}{{serverNameSsl}}{{else}}{{tenant}}{{/if}}$1 [R=301,L]


### PR DESCRIPTION
The invalidation URL should never be rewritten as the resulting redirect causes the flush to fail if the URL is requested with anything else but the primary hostname (which is often the case when internal IPs are used for communication between the hosts).