### PR TITLE
Make Minimal 'Dam Update Asset' workflow transient

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -22,7 +22,11 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/changes/1.0.0"
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
-
+    <release version="0.9.6">
+      <action type="update" dev="amuthmann">
+        Role aem-cms: Add option to make the minimal DAM Update Asset transient (default: true)
+      </action>
+    </release>
     <release version="0.9.4" date="2017-09-12">
       <action type="fix" dev="sseifert">
         Role aem-cms: Apply quickstart.enableDavEx parameter also on publish.

--- a/conga-aem-definitions/src/main/roles/aem-cms.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-cms.yaml
@@ -162,6 +162,7 @@ config:
 
   workflow:
     useMinimalDamUpdateAssetWorkflow: true
+    minimalDamUpdateAssetWorkflowTransient: true
 
 
 # Example tenant configuration. Tenant name = primary host name/server name

--- a/conga-aem-definitions/src/main/templates/aem-cms/aem-cms-author-dam-update-asset-workflow-minimal.json.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-cms/aem-cms-author-dam-update-asset-workflow-minimal.json.hbs
@@ -25,6 +25,10 @@
     "jcr:description": "This is a minimal \"DAM Update Asset\"-Workflow with only the core AEM DAM features.",
     "cq:tags": ["workflow:dam"],
     "sling:resourceType": "cq/workflow/components/pages/model",
+    {{~#if workflow.minimalDamUpdateAssetWorkflowTransient}}
+    "transient": "true",
+    {{~/if}}
+
     "flow": {
       "jcr:primaryType": "nt:unstructured",
       "sling:resourceType": "foundation/components/parsys",
@@ -96,6 +100,9 @@
       "title": "DAM Update Asset",
       "sling:resourceType": "cq/workflow/components/model",
       "metaData": {
+        {{~#if workflow.minimalDamUpdateAssetWorkflowTransient}}
+        "transient": "true",
+        {{~/if}}
         "jcr:primaryType": "nt:unstructured"
         },
       "nodes": {


### PR DESCRIPTION
Sadly I can't create branches, therefor a pull request :)

This change adds a configuration `minimalDamUpdateAssetWorkflowTransient` which defaults to true. If enabled, the Minimal Dam Update Asset Workflow is created as transient workflow in AEM.

Note: the Workflow Console does not care about this fact and show the Workflow as non-transient. But as soon as you open it, you can see, that the required flag is set.