### PR TITLE
Updated default access log format to not include client ip address

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="1.1.0" date="not released">
+      <action type="update" dev="trichter">
+        Role aem-dispatcher: No client ip logging by default.
+      </action>
       <action type="add" dev="trichter">
         Role aem-dispatcher: Introduce httpd.logging.errorLogLevel and httpd.logging.accessLogFormat to allow configuration of LogLevel and access log format.
       </action>

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
@@ -170,7 +170,7 @@ config:
     # Logging configuration
     logging:
       level: warn
-      accessLogFormat: combined
+      accessLogFormat: '"- %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\""'
 
     # Access restrictions
     accessRestriction:


### PR DESCRIPTION
Changed default log format from combined to custom log format in order to remove ip format from access.log (due to data privacy issues).