### PR TITLE
Add compatibility for setups with SSL offloading

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,18 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.3.0" date="not-released">
+      <action type="add" dev="trichter">
+        Role aem-dispatcher: Introduce httpd.ssl.offloading.active and httpd.ssl.offloading.rewriteCondition in order to support SSL offloading.
+      </action>
+      <action type="update" dev="trichter">
+        Role aem-dispatcher: Update rewriteHomepageRedirect to use https and httpd.serverNameSsl when SSL is enforced (used in SSL offloading setup)
+      </action>
+      <action type="update" dev="trichter">
+        Role aem-dispatcher: Always set Strict-Transport-Security header when SSL is enforced (used in SSL offloading setup)
+      </action>
+    </release>
+
     <release version="1.2.0" date="2018-02-05">
       <action type="add" dev="sseifert">
         Role aem-cms: Add (optional) support for deploying AEM crypto keys.

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
@@ -224,6 +224,13 @@ config:
       # If set to true all requests are redirectd to HTTPS and HSTS is enabled
       enforce: false
 
+      # SSL offloading configuration
+      offloading:
+        # if set to true a additional rewriteCondition will be added to the rewriteEnforcePrimaryHostname block to ensure
+        # requests forwarded for https are not rewritten to https
+        active: false
+        rewriteCondition: "%{HTTP:X-Forwarded-Proto} !https"
+
     # Redirecting from "/" (only publish dispatcher)
     rootRedirect:
       #url: /en.html

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.conf.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.conf.hbs
@@ -10,6 +10,10 @@
 {{#partial "rewriteEnforcePrimaryHostname"}}
 # Enforce SSL: Redirect all requests to HTTPS primary hostname (except for dispatcher invalidation)
 RewriteCond %{REQUEST_URI} !^/dispatcher/invalidate.cache
+{{~#if httpd.ssl.offloading.active}}
+# SSL Offloading: Disable primary hostname enforcing when forwarded from SSL offloader
+RewriteCond {{httpd.ssl.offloading.rewriteCondition}}
+{{/if~}}
 RewriteRule ^(.*)$ https://{{httpd.serverNameSsl}}$1 [R=301,L]
 {{/partial}}
 {{/if~}}

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.partials.hbs
@@ -73,7 +73,13 @@ Header set Cache-Control "public, must-revalidate"
 </LocationMatch>
 {{/block}}
 
-
+{{~#block "sslEnforce"}}
+{{~#if httpd.ssl.enforce}}
+# SSL enforcing
+# Enable HSTS if SSL is enforced, even on http (e.g. when running behind a ssl offloader)
+Header always set Strict-Transport-Security "max-age=31536000"
+{{/if}}
+{{/block}}
 
 {{~#block "searchRobotHeader"}}
 # Control indexing by search engine robots
@@ -195,7 +201,12 @@ RewriteRule ^/content/.* - [R=404,L,NC]
 {{~#block "rewriteHomepageRedirect"}}
 {{~#if httpd.rootRedirect.url}}
 # Root redirect to homepage
+{{#if httpd.ssl.enforce}}
+  {{ensureProperties "httpd.serverNameSsl" ~}}
+RewriteRule ^/$ https://{{httpd.serverNameSsl}}{{httpd.rootRedirect.url}} [R={{httpd.rootRedirect.httpStatus}},L]
+{{~ else}}
 RewriteRule ^/$ {{httpd.rootRedirect.url}} [R={{httpd.rootRedirect.httpStatus}},L]
+{{/if ~}}
 {{/if ~}}
 {{/block}}
 

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.ssl.conf.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.ssl.conf.hbs
@@ -31,12 +31,6 @@ RewriteRule ^(.*)$ https://{{httpd.serverNameSsl}}$1 [R=301,L]
 
 {{> aem-dispatcher/publish/vhost_publish_tenant.partials.hbs}}
 
-
-{{~#if httpd.ssl.enforce}}
-# Enable HSTS if SSL is enforced
-Header always set Strict-Transport-Security "max-age=31536000"
-{{/if}}
-
 # SSL configuration
 SSLEngine on
 SSLCertificateFile      {{httpd.ssl.certificateFile}}


### PR DESCRIPTION
In a setup with a SSL Offloader the website is only served via http to the loadbalancer.

As de-facto standard the loadbalancer/offloader normally sends the "X-Forwarded-For: https" header.

To support this setup the following changes were implemented:
* Always add "Strict-Transport-Security" header when ssl is enforced
* The rewriteHomepageRedirect should directly redirect to the SSL hostname (since Apache is not running with SSL he will redirect to http://... otherwise)
* The rewritePrimaryHostname mechanism was adjusted to detect requests that were originally forwarded for https