### PR TITLE
Role aem-dispatcher: Introduce httpd.remoteIPInternalProxies to allow…

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.3.0" date="not-released">
+      <action type="add" dev="trichter">
+        Role aem-dispatcher: Introduce httpd.remoteIPInternalProxies to allow configuration of addresses (or address blocks) to trust as presenting a valid RemoteIPHeader value of the useragent IP.
+      </action>
+    </release>
+
     <release version="1.2.0" date="2018-02-05">
       <action type="add" dev="sseifert">
         Role aem-cms: Add (optional) support for deploying AEM crypto keys.

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
@@ -250,6 +250,11 @@ config:
       # Placed at the bottom of the vhost confign file
       after:
 
+    # Configures adresses (or address blocks) to trust as presenting a valid RemoteIPHeader (use in loadbalancer setup where client ip forwarding is needed)
+    remoteIPInternalProxies:
+    # - 10.0.2.0/24
+    # - gateway.localdomain
+
   dispatcher:
     
     # Hostname and port of AEM instance

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.partials.hbs
@@ -42,6 +42,14 @@ TraceEnable Off
 RewriteEngine On
 {{/block}}
 
+{{~#block "remoteIPForwarding"}}
+{{~#if httpd.remoteIPInternalProxies}}
+# Trusted remote ip proxies
+{{~#each httpd.remoteIPInternalProxies}}
+RemoteIPInternalProxy {{this}}
+{{~/each}}
+{{~/if}}
+{{/block}}
 
 {{~#block "dispatcherModule"}}
 # Enable AEM dispatcher module


### PR DESCRIPTION
… configuration of addresses (or address blocks) to trust as presenting a valid RemoteIPHeader value of the useragent IP.