### PR TITLE
Specify sensitiveConfigParameters also in aem-dispatcher otherwise dispatcher model.yaml will contain unencrypted parameters

### DIFF
--- a/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
@@ -398,3 +398,9 @@ config:
 #      Custom Config Line 1
 #      Custom Config Line 2
 #  sling.mapping.rootPath: /content/path
+
+# Configuration parameter that should be encrypted in model export YAML file
+sensitiveConfigParameters:
+- quickstart.adminUser.password
+- quickstart.adminUser.passwordOld
+- replication.author.publishTargets.transportPassword


### PR DESCRIPTION
We have to specify the `sensitiveConfigParameters` in the aem-dispatcher role as well otherwise they will be rendered unencrypted in the dispatchers model.yaml