### PR TITLE
 Sanitize replication agent names by replacing dots with underscores

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.4.2" date="not released">
+      <action type="update" dev="trichter">
+        Role aem-cms: Sanitize replication agent names by replacing dots with underscores.
+      </action>
+    </release>
+
     <release version="1.4.0" date="2018-07-02">
       <action type="update" dev="sseifert">
         Role aem-cms: Set workflow.useMinimalDamUpdateAssetWorkflow to false by default because DAM update asset workflow definitions differ between AEM versions.

--- a/conga-aem-definitions/pom.xml
+++ b/conga-aem-definitions/pom.xml
@@ -51,7 +51,7 @@
       <plugin>
         <groupId>io.wcm.devops.conga</groupId>
         <artifactId>conga-maven-plugin</artifactId>
-        <version>1.9.2</version>
+        <version>1.9.3-SNAPSHOT</version>
         <extensions>true</extensions>
         <dependencies>
 

--- a/conga-aem-definitions/src/main/templates/aem-cms/aem-cms-author-replicationagents.json.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-cms/aem-cms-author-replicationagents.json.hbs
@@ -13,7 +13,7 @@
     }
 
 {{#each replication.author.publishTargets}},
-    "publish_{{this.name}}": {
+    "publish_{{replace this.name "." "_"}}": {
       "jcr:primaryType": "cq:Page",
       "jcr:content": {
         "jcr:primaryType": "nt:unstructured",
@@ -33,7 +33,7 @@
 {{/each}}
 
 {{#with replication.author.flushTarget}}{{#if this.name}},
-    "flush_{{this.name}}": {
+    "flush_{{replace this.name "." "_"}}": {
       "jcr:primaryType": "cq:Page",
       "jcr:content": {
         "jcr:primaryType": "nt:unstructured",

--- a/conga-aem-definitions/src/main/templates/aem-cms/aem-cms-publish-replicationagents.json.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-cms/aem-cms-publish-replicationagents.json.hbs
@@ -13,7 +13,7 @@
     }
 
 {{#with replication.publish.flushTarget}}{{#if this.name}},
-    "flush_{{this.name}}": {
+    "flush_{{replace this.name "." "_"}}": {
       "jcr:primaryType": "cq:Page",
       "jcr:content": {
         "jcr:primaryType": "nt:unstructured",

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -55,7 +55,7 @@
       <plugin>
         <groupId>io.wcm.devops.conga</groupId>
         <artifactId>conga-maven-plugin</artifactId>
-        <version>1.9.2</version>
+        <version>1.9.3-SNAPSHOT</version>
         <extensions>true</extensions>
         <dependencies>
 

--- a/example/src/main/environments/test-aem63.yaml
+++ b/example/src/main/environments/test-aem63.yaml
@@ -2,27 +2,30 @@
 
 nodes:
 
-- node: aem-author
+- node: aem-author.dev.net
   roles:
   - role: aem-cms
     variant: aem-author
   config:
     replication.author.publishTargets:
-    - name: publish1
+    - name: aem-publish.dev.net
       url: http://localhost:4503
       transportUser: admin
       transportPassword: admin
+    replication.author.flushTarget:
+      name: webserver.dev.net
+      url: http://author.sample1.com
 
-- node: aem-publish
+- node: aem-publish.dev.net
   roles:
   - role: aem-cms
     variant: aem-publish
   config:
     replication.publish.flushTarget:
-      name: dispatcher1
-      url: http:/www.sample1.com
+      name: webserver.dev.net
+      url: http://www.sample1.com
 
-- node: webserver
+- node: webserver.dev.net
   roles:
   - role: aem-dispatcher
     variants:


### PR DESCRIPTION
Dots in replication agent names currently lead to an exception in AEM since `.` is not allowed in agent names.

e.g.
```
- node: dev.website1.com
  roles:
  - role: aem-fe-archetype-aem-cms-combined
    variant: aem-publish
    config:
      replication.publish.flushTarget:
        name: ${node.replace(".","_")}
        url: https://${node}
```

This PR depends on: https://github.com/wcm-io-devops/conga/pull/2