### PR TITLE
Restrict caching of aem-author instances

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,10 +23,18 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
-
     <release version="1.4.4" date="not released">
       <action type="fix" dev="trichter">
         Fix aem-author dispatcher caching.
+      </action>
+    </release>
+
+    <release version="1.4.2" date="2018-08-17">
+      <action type="update" dev="trichter">
+        Role aem-cms: Sanitize replication agent names by replacing dots with underscores.
+      </action>
+      <action type="update" dev="trichter">
+        Role aem-cms: Add custom httpd port support for publish sling mapping.
       </action>
     </release>
 

--- a/changes.xml
+++ b/changes.xml
@@ -23,12 +23,10 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
-    <release version="1.4.2" date="2018-08-17">
-      <action type="update" dev="trichter">
-        Role aem-cms: Sanitize replication agent names by replacing dots with underscores.
-      </action>
-      <action type="update" dev="trichter">
-        Role aem-cms: Add custom httpd port support for publish sling mapping.
+
+    <release version="1.4.4" date="not released">
+      <action type="fix" dev="trichter">
+        Fix aem-author dispatcher caching.
       </action>
     </release>
 

--- a/changes.xml
+++ b/changes.xml
@@ -25,7 +25,7 @@
 
     <release version="1.4.4" date="not released">
       <action type="fix" dev="trichter">
-        Fix aem-author dispatcher caching.
+        Remove aem-author dispatcher caching.
       </action>
     </release>
 

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
@@ -313,21 +313,6 @@ config:
       # information present in the request
       - glob: "*"
         type: deny
-      # Allow caching of clientlibs
-      - glob: "/libs/*/clientlibs/*.js*"
-        type: allow
-      - glob: "/libs/*/clientlibs/*.css*"
-        type: allow
-      - glob: "/etc/*/clientlibs/*.js*"
-        type: allow
-      - glob: "/etc/*/clientlibs/*.css*"
-        type: allow
-      # Thumbnails exist in various resolutions: thumbnail.png, thumbnail.png.thumb.48.48.png
-      - glob: "/content/*/*.thumb.*.png*"
-        type: allow
-      # Static ressources in /apps
-      - glob: "/apps/*/docroot/*"
-        type: allow
 
       # Defines the pages that are "invalidated" after any activation
       invalidate:

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
@@ -313,25 +313,20 @@ config:
       # information present in the request
       - glob: "*"
         type: deny
-      # Allow caching of requests to /libs
-      - glob: "/libs/*"
+      # Allow caching of clientlibs
+      - glob: "/libs/*/clientlibs/*.js*"
         type: allow
-      # This contains user information
-      - glob: "/libs/cq/security/userinfo.*"
-        type: deny
-      # This page contains a "Welcome, User XXX" message
-      - glob: "/libs/cq/core/content/welcome.*"
-        type: deny
+      - glob: "/libs/*/clientlibs/*.css*"
+        type: allow
+      - glob: "/etc/*/clientlibs/*.js*"
+        type: allow
+      - glob: "/etc/*/clientlibs/*.css*"
+        type: allow
       # Thumbnails exist in various resolutions: thumbnail.png, thumbnail.png.thumb.48.48.png
-      - glob: "/apps/*/templates/*/thumbnail.pn*"
+      - glob: "/content/*/*.thumb.*.png*"
         type: allow
       # Static ressources in /apps
       - glob: "/apps/*/docroot/*"
-        type: allow
-      # Client Libraries
-      - glob: "/etc/clientlibs/*"
-        type: allow
-      - glob: "/etc/designs/*/clientlibs/*"
         type: allow
 
       # Defines the pages that are "invalidated" after any activation


### PR DESCRIPTION
The current cache settings for the aem-author dispatcher results in problems with cached pages in the administration section of AEM.

Adobe recommends to not cache anything in the author dispatcher (see https://helpx.adobe.com/experience-manager/dispatcher/using/dispatcher.html#UsingaDispatcherwithanAuthorServer) but i assume that caching js and css files of the clientlibs below /libs and /etc should be safe.