### PR TITLE
Add ssl offloading to aem-author dispatcher variants

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.4.6" date="not released">
+      <action type="add" dev="trichter">
+        Role aem-dispatcher: use httpd.ssl.offloading.enabled and httpd.ssl.offloading.rewriteCondition for variant aem-author.
+      </action>
+    </release>
+
     <release version="1.4.4" date="2019-01-15">
       <action type="fix" dev="trichter">
         Role aem-dispatcher: Disable dispatcher caching for author instance.

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.conf.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.conf.hbs
@@ -11,8 +11,8 @@
 # Enforce SSL: Redirect all requests to HTTPS primary hostname (except for dispatcher invalidation)
 RewriteCond %{REQUEST_URI} !^/dispatcher/invalidate.cache
 {{~#if httpd.ssl.offloading.enabled}}
-  # SSL Offloading: Disable primary hostname enforcing when forwarded from SSL offloader
-  RewriteCond {{httpd.ssl.offloading.rewriteCondition}}
+# SSL Offloading: Disable primary hostname enforcing when forwarded from SSL offloader
+RewriteCond {{httpd.ssl.offloading.rewriteCondition}}
 {{~/if}}
 RewriteRule ^(.*)$ https://{{httpHostSsl httpd.serverNameSsl port=httpd.serverPortSsl}}$1 [R=301,L]
 {{/partial}}

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.conf.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.conf.hbs
@@ -10,6 +10,10 @@
 {{#partial "rewriteEnforcePrimaryHostname"}}
 # Enforce SSL: Redirect all requests to HTTPS primary hostname (except for dispatcher invalidation)
 RewriteCond %{REQUEST_URI} !^/dispatcher/invalidate.cache
+{{~#if httpd.ssl.offloading.enabled}}
+  # SSL Offloading: Disable primary hostname enforcing when forwarded from SSL offloader
+  RewriteCond {{httpd.ssl.offloading.rewriteCondition}}
+{{~/if}}
 RewriteRule ^(.*)$ https://{{httpHostSsl httpd.serverNameSsl port=httpd.serverPortSsl}}$1 [R=301,L]
 {{/partial}}
 {{/if~}}


### PR DESCRIPTION
The functionality for publish instances was added with https://github.com/wcm-io-devops/conga-aem-definitions/pull/24, but I missed to update the author instances.