### PR TITLE
Role aem-cms: Introduce sling.mapping.generatePackage

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="1.4.6" date="not released">
+      <action type="add" dev="trichter">
+        Role aem-cms: Introduce sling.mapping.generatePackage to allow disabling of the sling mapping package.
+      </action>
       <action type="update" dev="trichter">
         Role aem-dispatcher: use httpd.ssl.offloading.enabled and httpd.ssl.offloading.rewriteCondition for variant aem-author.
       </action>

--- a/conga-aem-definitions/src/main/roles/aem-cms.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-cms.yaml
@@ -22,6 +22,7 @@ files:
   template: aem-cms-publish-slingmapping.json.hbs
   variants:
   - aem-publish
+  condition: ${sling.mapping.generatePackage}
   postProcessors:
   - aem-contentpackage
   postProcessorOptions:
@@ -187,6 +188,8 @@ config:
 
     # Configure Sling Mapping for URL shortening of content paths
     mapping:
+      # generate aem-cms-publish-slingmapping package by default
+      generatePackage: true
       # Content root path which is stripped off
       #rootPath: /content/path
 


### PR DESCRIPTION
Introduced sling.mapping.generatePackage to allow disabling of the sling mapping package.

In some cases this is necessary, because otherwise the existing (legacy) sling mapping will be overwritten.