### PR TITLE
Role aem-cms: Increase default quickstart.stopTimeout to 1200 seconds.

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -30,6 +30,9 @@
       <action type="update" dev="mrozati" issue="WDCONGA-22">
         Apply the publish sling mappings only on instances with publish runmode.
       </action>
+      <action type="update" dev="trichter" >
+        Role aem-cms: Increase default quickstart.stopTimeout to 1200 seconds.
+      </action>
     </release>
 
     <release version="1.4.4" date="2019-01-15">

--- a/conga-aem-definitions/src/main/roles/aem-cms.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-cms.yaml
@@ -172,7 +172,7 @@ config:
     # AEM root path where quickstart jar is located
     rootPath: /opt/adobe/aem-author
     # Seconds to wait for instance to be stopped until process is killed
-    stopTimeout: 180
+    stopTimeout: 1200
 
     # AEM/Sling admin user
     adminUser:


### PR DESCRIPTION
Our conga roles are using or are going to use a default stop timeout of 1200 seconds so we should increase this timeout here too. 180 seconds or 3 minutes was also a little bit too optimistic.