### PR TITLE
Dispatcher Flush Agen: add `aliasUpdate` flag 

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.6.2" date="not-released">
+      <action type="update" dev="mrozati">
+        Dispatcher Flush Agent: support "aliasUpdate" flag, which is needed when using sling:alias or vanity URLs
+      </action>
+    </release>
+
     <release version="1.6.0" date="2019-11-22">
       <action type="add" dev="nbellack">
         Role aem-dispatcher: Add http2 variant which provides HTTP/2 support.

--- a/conga-aem-definitions/src/main/roles/aem-cms.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-cms.yaml
@@ -191,12 +191,14 @@ config:
       flushTarget:
         #name: dispatcherAuthor1
         #url: http://localhost:8000
+        aliasUpdate: false
       # generate replicationagents package by default
       generatePackage: true
     publish:
       flushTarget:
         #name: dispatcherPublish1
         #url: http://localhost:8000
+        aliasUpdate: false
       # generate replicationagents package by default
       generatePackage: true
 

--- a/conga-aem-definitions/src/main/roles/aem-cms.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-cms.yaml
@@ -191,6 +191,7 @@ config:
       flushTarget:
         #name: dispatcherAuthor1
         #url: http://localhost:8000
+        # set aliasUpdate to true if you use sling:alias or vanity urls. This will send a flush request with both the original path and the vanity path with aliases
         aliasUpdate: false
       # generate replicationagents package by default
       generatePackage: true
@@ -198,6 +199,7 @@ config:
       flushTarget:
         #name: dispatcherPublish1
         #url: http://localhost:8000
+        # set aliasUpdate to true if you use sling:alias or vanity urls. This will send a flush request with both the original path and the vanity path with aliases
         aliasUpdate: false
       # generate replicationagents package by default
       generatePackage: true

--- a/conga-aem-definitions/src/main/templates/aem-cms/aem-cms-author-replicationagents.json.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-cms/aem-cms-author-replicationagents.json.hbs
@@ -49,6 +49,7 @@
         "triggerModified": "true",
         "noVersioning": "true",
         "noStatusUpdate": "true",
+        "aliasUpdate": "{{this.aliasUpdate}}",
         "protocolHTTPMethod": "GET",
         "protocolHTTPHeaders": [
           "CQ-Action:{action}",

--- a/conga-aem-definitions/src/main/templates/aem-cms/aem-cms-publish-replicationagents.json.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-cms/aem-cms-publish-replicationagents.json.hbs
@@ -28,7 +28,7 @@
         "triggerReceive": "true",
         "triggerSpecific": "true",
         "noVersioning": "true",
-        "aliasUpdate": {{defaultIfEmpty this.aliasUpdate false}},
+        "aliasUpdate": "{{this.aliasUpdate}}",
         "protocolHTTPMethod": "GET",
         "protocolHTTPHeaders": [
           "CQ-Action:{action}",

--- a/conga-aem-definitions/src/main/templates/aem-cms/aem-cms-publish-replicationagents.json.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-cms/aem-cms-publish-replicationagents.json.hbs
@@ -28,6 +28,7 @@
         "triggerReceive": "true",
         "triggerSpecific": "true",
         "noVersioning": "true",
+        "aliasUpdate": {{defaultIfEmpty this.aliasUpdate false}},
         "protocolHTTPMethod": "GET",
         "protocolHTTPHeaders": [
           "CQ-Action:{action}",


### PR DESCRIPTION
aliasUpdate is needed when the website uses sling:alias or vanity URLs. default: false
see https://helpx.adobe.com/experience-manager/6-5/sites/deploying/using/replication.html#ConfiguringaDispatcherFlushagent