### PR TITLE
CORS Header: Add required protocol to the example origins to be white…

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="1.6.4" date="not released">
+      <action type="update" dev="mceruti">
+        CORS Header: Add required protocol to the example origins to be whitelisted 
+      </action>
       <action type="update" dev="sseifert">
         Set packageType and enable FileVault validation for all CONGA-generated content packages.
       </action>

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
@@ -288,8 +288,8 @@ config:
       # If set to false only the requesting host is all if it is in the hostWhiteList (or this list is empty), and not in the hostBlackList
       allowAllHosts: true
       #hostWhiteList:
-      #- www.host1.com
-      #- www.host2.com
+      #- "https://www.host1.com"
+      #- "https://www.host2.com"
 
     headers:
       # Enables/Configures the Content-Security-Policy header on publish dispatcher (see https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)


### PR DESCRIPTION
I've been able to to use conga to generate an appropriate httpd directive that creates the CORS Header for specific locations and whitelisted origins by specifying config.httpd.corsHeader.hostWhiteList array. However at first it did not work when I followed the [example](https://github.com/wcm-io-devops/conga-aem-definitions/blob/339a5d96ea5c2658fe6ab56fff3890ca55d9b077/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml#L290) and only specified host-names. I found out that the generated directive SetEnvIf did not match the regexp because it does not include the http(s):// prefix:
```
<LocationMatch "\.alerts\.json$">
  SetEnvIf Origin "^(\Qwww.host1.com\E)$" AccessControlAllowOrigin=$0
  Header add Access-Control-Allow-Origin "%{AccessControlAllowOrigin}e" env=AccessControlAllowOrigin
  Header merge Vary Origin
</LocationMatch>
```
I then specified not only the hostname but also the http protocol:
```
hostWhiteList:
     - "https://www.host1.com"
```
and with this it all works fine. With my PR I therefore suggest to update the examples.






