### PR TITLE
Add httpd.headers.cacheControl to aem-dispatcher role

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -30,6 +30,9 @@
       <action type="update" dev="mrozati">
         Role aem-dispatcher: Add mimetype application/manifest+json for extension webmanifest
       </action>
+      <action type="add" dev="nbellack">
+        Role aem-dispatcher: Add httpd.headers.cacheControl
+      </action>
     </release>
 
     <release version="1.7.0" date="2020-04-28">

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
@@ -283,6 +283,11 @@ config:
       referrerPolicy: "origin-when-cross-origin"
       # Enables/Configures the X-XSS-Protection header on publish dispatcher (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection)
       xssProtection:
+      # Enables/Configures the Cache-Control header on publish dispatcher (see https://developer.mozilla.org/en/docs/Web/HTTP/Headers/Cache-Control)
+      cacheControl:
+        # Cache AEM Clientlibs with long cache key for 1 year
+        - locationMatch: "\\.lc-.*-lc\\.min\\.(css|js)$"
+          directives: "max-age=31536000, public"
 
     # Custom configuration snippets for vhost files (only on publish dispatcher - useful for tenant-specific configurations)
     customVHostConfig:

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
@@ -303,6 +303,11 @@ config:
       referrerPolicy: "origin-when-cross-origin"
       # Enables/Configures the X-XSS-Protection header on publish dispatcher (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection)
       xssProtection:
+      # Enables/Configures the Cache-Control header on publish dispatcher (see https://developer.mozilla.org/en/docs/Web/HTTP/Headers/Cache-Control)
+      cacheControl:
+        # Cache AEM Clientlibs with long cache key for 1 year
+        - locationMatch: "\\.lc-.*-lc\\.min\\.(css|js)$"
+          directives: "max-age=31536000, public"
 
     # Custom configuration snippets for vhost files (only on publish dispatcher - useful for tenant-specific configurations)
     customVHostConfig:

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -86,11 +86,11 @@ TraceEnable Off
 {{~#block "cacheControl"}}
 # Cache-control
 Header set Cache-Control "public, must-revalidate"
-
-# Cache AEM Clientlibs with long cache key for 1 year
-<LocationMatch "\.lc-.*-lc\.min\.(css|js)$">
-  Header set Cache-Control "max-age=31536000, public"
+{{#each httpd.headers.cacheControl}}
+<LocationMatch "{{this.locationMatch}}">
+  Header set Cache-Control "{{this.directives}}"
 </LocationMatch>
+{{~/each}}
 {{/block}}
 
 {{~#block "searchRobotHeader"}}

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.partials.hbs
@@ -85,11 +85,11 @@ RemoteIPInternalProxy {{this}}
 {{~#block "cacheControl"}}
 # Cache-control
 Header set Cache-Control "public, must-revalidate"
-
-# Cache AEM Clientlibs with long cache key for 1 year
-<LocationMatch "\.lc-.*-lc\.min\.(css|js)$">
-  Header set Cache-Control "max-age=31536000, public"
+{{#each httpd.headers.cacheControl}}
+<LocationMatch "{{this.locationMatch}}">
+  Header set Cache-Control "{{this.directives}}"
 </LocationMatch>
+{{/each~}}
 {{/block}}
 
 {{~#block "sslEnforce"}}

--- a/example/src/main/environments/test-aem63.yaml
+++ b/example/src/main/environments/test-aem63.yaml
@@ -121,6 +121,11 @@ config:
       cACertificateFile: /etc/ssl/certs/sample.pem
     serverPort: 8080
     serverPortSsl: 8443
+    headers:
+      cacheControl:
+        - _merge_
+        - locationMatch: "\\.(woff2|woff)$"
+          directives: "max-age=31536000, public"
 
   sling:
     caconfig:

--- a/example/src/main/environments/test.yaml
+++ b/example/src/main/environments/test.yaml
@@ -212,4 +212,8 @@ tenants:
         contentSecurityPolicy: "script-src 'self' 'unsafe-inline' 'unsafe-eval' *.sample1.com;"
         xssProtection: "1; mode=block"
         referrerPolicy: "strict-origin-when-cross-origin"
+        cacheControl:
+          - _merge_
+          - locationMatch: "\\.json.*$"
+            directives: "max-age=10, public"
     sling.mapping.rootPath: /content/sample2


### PR DESCRIPTION
This enables you to configure multiple Cache-Control headers for various locations.