### PR TITLE
Role aem-dispatcher-cloud: Introduce httpd.docroot 

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="1.7.2" date="not released">
+      <action type="add" dev="trichter">
+        Role aem-dispatcher-cloud: Introduce httpd.docroot in order to cover scenarios where variable is named differently.
+      </action>
       <action type="update" dev="mceruti">
         Role aem-dispatcher, aem-dispatcher-cloud: CORS Header - Add required protocol to the example origins to be whitelisted
       </action>

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
@@ -259,6 +259,9 @@ config:
     serverName:
     serverAliasNames:
 
+    # The document root variable used in httpd configuration files
+    docroot: "\\${DOCROOT}"
+
     # Redirecting from "/" (only publish dispatcher)
     rootRedirect:
       #url: /en.html

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -27,7 +27,7 @@ ServerAlias {{this}}
 
 {{~#block "generalSettings"}}
 ## Use a document root that matches the one in conf.dispatcher.d/default.farm
-DocumentRoot "${DOCROOT}"
+DocumentRoot "{{httpd.docroot}}"
 ## Add header breadcrumbs for help in troubleshooting
 <IfModule mod_headers.c>
 	Header add X-Vhost "publish"
@@ -55,7 +55,7 @@ DocumentRoot "${DOCROOT}"
 	#### Prevent clickjacking
 	Header always append X-Frame-Options SAMEORIGIN
 </Directory>
-<Directory "${DOCROOT}">
+<Directory "{{httpd.docroot}}">
 	AllowOverride None
 	Require all granted
 </Directory>

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.dispatcher.d/available_farms/publish.farm.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.dispatcher.d/available_farms/publish.farm.hbs
@@ -39,7 +39,7 @@
 	/cache {
 
 		## The cacheroot must be equal to the document root of the webserver
-		/docroot "${DOCROOT}"
+		/docroot "{{httpd.docroot}}"
 
 		## sets the level upto which files named ".stat" will be created in the 
 		## document root of the webserver. when an activation request for some 

--- a/example/src/main/environments/test.yaml
+++ b/example/src/main/environments/test.yaml
@@ -110,6 +110,7 @@ nodes:
           - location: /admin
             type: allow
           - _merge_
+        docroot: "\\${PUBLISH_DOCROOT}"
       dispatcher:
         cache:
           rootPath: /var/cache/publish1


### PR DESCRIPTION
When using aem-dispatcher-cloud role in AMS setups we need to be able to reconfigure the used variable name for the docroot. In AMS Setups the name for example is `${PUBLISH_DOCROOT}` (beside the `${AUTHOR_DOCROOT}`