### PR TITLE
Fix typo in aem-dispatcher.yaml

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.11.0" date="not released">
+      <action type="fix" dev="nbellack">
+        Correctly use serverAliasNamesSsl as a list in aem-dispatcher.yaml.
+      </action>
+    </release>
+
     <release version="1.10.0" date="2020-11-24">
       <action type="add" dev="trichter">
         Add new role Role aem-dispatcher-ams.

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
@@ -218,7 +218,8 @@ config:
     serverName:
     serverNameSsl: ${httpd.serverName}
     serverAliasNames:
-    serverAliasNamesSsl: ${httpd.serverAliasNames}
+    serverAliasNamesSsl:
+      - ${httpd.serverAliasNames}
 
     # Server ports
     serverPort: 80


### PR DESCRIPTION
This was probably a typo, since it is correctly used as a list in all other places.

_Not_ handling these entries as list items results in faulty rendered VHost files:

```
# Alternative hostnames
ServerAlias [B@5eaa4ed0
ServerAlias false
```