### PR TITLE
Also allow IPv6 as X-Forwarded-For

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -22,7 +22,13 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/changes/1.0.0"
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
-
+    
+    <release version="1.11.0"">
+      <action type="add" dev="amuthmann">
+        Also allow ipv6 as X-Forwarded-For header
+      </action>
+    </release>
+    
     <release version="1.10.0" date="2020-11-24">
       <action type="add" dev="trichter">
         Add new role Role aem-dispatcher-ams.

--- a/conga-aem-definitions/src/main/resources/aem-sdk-dispatcher/src/conf.d/rewrites/default_rewrite.rules
+++ b/conga-aem-definitions/src/main/resources/aem-sdk-dispatcher/src/conf.d/rewrites/default_rewrite.rules
@@ -24,6 +24,9 @@
 # Prevent X-FORWARDED-FOR spoofing
 RewriteCond %{HTTP:X-Forwarded-For} !^$
 RewriteCond %{HTTP:X-Forwarded-For} !^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}
+# For IPv6
+RewriteCond %{HTTP:X-Forwarded-For} !^([0-9A-Fa-f]{0,4}:){2,7}([0-9A-Fa-f]{1,4}$|((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})
+RewriteCond %{HTTP:X-Forwarded-For} !^[a-fA-F0-9:]+,?.*
 RewriteRule .* - [F]
 
 # Uncomment to force HSTS protection


### PR DESCRIPTION
This change also allows X-Forwarded-For IPv6 addresses (aligns with https://github.com/adobe/aem-project-archetype/commit/fa66349b6a5167fda9ae543644e3524130e4ecf4#diff-a2d5de89d5fa9071fe9e8184bc4639154a273e0ac6d39ef6b01c1ff1a5e71e39)