### PR TITLE
Don't compress mp4 / webm videos as this prevents streaming

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -22,7 +22,11 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/changes/1.0.0"
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
-
+    <release version="1.12.0" data="unreleased">
+      <action type="add" dev="amuthmann">
+        Prevent gzip for videos (mp4 and webm) to allow streaming.
+      </action>
+    </release>
     <release version="1.10.0" date="2020-11-24">
       <action type="add" dev="trichter">
         Add new role Role aem-dispatcher-ams.

--- a/changes.xml
+++ b/changes.xml
@@ -22,7 +22,7 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/changes/1.0.0"
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
-    <release version="1.12.0" data="unreleased">
+    <release version="1.11.0" data="unreleased">
       <action type="add" dev="amuthmann">
         Prevent gzip for videos (mp4 and webm) to allow streaming.
       </action>

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-ams/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-ams/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -67,8 +67,8 @@ DocumentRoot "${PUBLISH_DOCROOT}"
   AllowOverride None
   # Insert filter
   SetOutputFilter DEFLATE
-  # Don't compress images
-  SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png)$ no-gzip dont-vary
+  # Don't compress images & videos
+  SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png|webm|mp4)$ no-gzip dont-vary
   # Make sure proxies don't deliver the wrong content
   Header append Vary User-Agent env=!dont-vary
   # Prevent clickjacking

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -54,8 +54,8 @@ DocumentRoot "${DOCROOT}"
   AllowOverride None
   # Insert filter
   SetOutputFilter DEFLATE
-  # Don't compress images
-  SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png)$ no-gzip dont-vary
+  # Don't compress images & videos
+  SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png|webm|mp4)$ no-gzip dont-vary
   # Make sure proxies don't deliver the wrong content
   Header append Vary User-Agent env=!dont-vary
   # Prevent clickjacking


### PR DESCRIPTION
Modern browsers use Requests that include the "Range" Header to stream videos. This does not work with gzip, therefor video formats need to be excluded from gzip.