### PR TITLE
Role: aem-cms: Remove "jvm.path" configuration option

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -26,6 +26,9 @@
       <action type="add" dev="amuthmann">
         Prevent gzip for videos (mp4 and webm) to allow streaming.
       </action>
+      <action type="add" dev="trichter">
+        Role: aem-cms: Remove "jvm.path" configuration option
+      </action>
     </release>
     <release version="1.10.0" date="2020-11-24">
       <action type="add" dev="trichter">

--- a/conga-aem-definitions/src/main/roles/aem-cms.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-cms.yaml
@@ -136,7 +136,6 @@ config:
     version: ${version}
 
   jvm:
-    path: /path/to/java
     heapspace:
       min: 2048m
       max: 2048m

--- a/conga-aem-definitions/src/main/templates/aem-cms/start.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-cms/start.hbs
@@ -6,8 +6,6 @@
 # **************************************************************************************
 
 ### BEGIN customized AEM quickstart settings
-export JAVA_HOME="{{jvm.path}}"
-export PATH="$JAVA_HOME/bin:$PATH"
 export CQ_PORT="{{quickstart.port}}"
 export CQ_RUNMODE="{{join quickstart.runmodes ','}}"
 export CQ_JVM_OPTS="-server -Xms{{jvm.heapspace.min}} -Xmx{{jvm.heapspace.max}} -XX:MaxPermSize={{jvm.permgenspace.max}}"

--- a/example/src/main/environments/test-aem63.yaml
+++ b/example/src/main/environments/test-aem63.yaml
@@ -94,8 +94,6 @@ nodes:
         - host
 
 config:
-  jvm.path: /usr/lib/jvm/jdk-8-oracle-x64
-
   quickstart:
     enableDavEx: true
     adminUser:

--- a/example/src/main/environments/test.yaml
+++ b/example/src/main/environments/test.yaml
@@ -209,8 +209,6 @@ nodes:
 
 
 config:
-  jvm.path: /usr/lib/jvm/jdk-8-oracle-x64
-
   quickstart:
     enableDavEx: true
     adminUser:


### PR DESCRIPTION
As discussed this setting was never set correctly in our environments and thus had no effect and can be removed.