### PR TITLE
Use dict instead of list for cloudManagerConditional

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -29,6 +29,9 @@
       <action type="add" dev="trichter">
         Role: aem-cms: Remove "jvm.path" configuration option
       </action>
+      <action type="fix" dev="nbellack">
+        Role aem-dispatcher-cloud, aem-dispatcher-ams: Fix usage example for cloudManagerConditional directive
+      </action>
     </release>
     <release version="1.10.0" date="2020-11-24">
       <action type="add" dev="trichter">

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-ams.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-ams.yaml
@@ -363,7 +363,7 @@ config:
 
     # Allows to define server names/alias names per environment in a single dispatcher configuration
     #cloudManagerConditional:
-    #  - targetEnvironment: dev
+    #  targetEnvironment:  # to be substituted with e.g. "dev"
     #    serverName: www.dev-host3.com
     #    serverAliasNames:
     #    - www.dev-alias3a.com

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
@@ -353,7 +353,7 @@ config:
 
     # Allows to define different server names/alias names per environment in a single dispatcher configuration
     #cloudManagerConditional:
-    #  - targetEnvironment: dev
+    #  targetEnvironment:  # to be substituted with e.g. "dev"
     #    serverName: www.dev-host3.com
     #    serverAliasNames:
     #    - www.dev-alias3a.com


### PR DESCRIPTION
The current example in the dispatcher roles is misleading because `cloudManagerConditional` expects a dictionary and not a list. It is correctly used in the [examples](https://github.com/wcm-io-devops/conga-aem-definitions/blob/develop/example/src/main/environments/test.yaml#L307), though.