### PR TITLE
Set httpd.rootRedirect.url to HTTPS version of VHost

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -35,6 +35,9 @@
       <action type="add" dev="nbellack">
         Role aem-dispatcher: Don't show exact Apache/Dispatcher version in Server header
       </action>
+      <action type="fix" dev="nbellack">
+        Role aem-dispatcher-cloud: Set httpd.rootRedirect.url to HTTPS version of VHost
+      </action>
     </release>
     <release version="1.10.0" date="2020-11-24">
       <action type="add" dev="trichter">

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -190,7 +190,7 @@ RewriteRule ^/(.+)$ /content/$1 [PT,L]
 {{~#block "rewriteHomepageRedirect"}}
 {{~#if httpd.rootRedirect.url}}
 # Root redirect to homepage
-RewriteRule ^/$ {{httpd.rootRedirect.url}} [R={{httpd.rootRedirect.httpStatus}},L]
+RewriteRule ^/$ https://%{HTTP_HOST}{{httpd.rootRedirect.url}} [R={{httpd.rootRedirect.httpStatus}},L]
 {{/if ~}}
 {{/block}}
 

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -190,7 +190,7 @@ RewriteRule ^/(.+)$ /content/$1 [PT,L]
 {{~#block "rewriteHomepageRedirect"}}
 {{~#if httpd.rootRedirect.url}}
 # Root redirect to homepage
-RewriteRule ^/$ https://%{HTTP_HOST}{{httpd.rootRedirect.url}} [R={{httpd.rootRedirect.httpStatus}},L]
+RewriteRule ^/$ https://{{httpd.serverName}}{{httpd.rootRedirect.url}} [R={{httpd.rootRedirect.httpStatus}},L]
 {{/if ~}}
 {{/block}}
 


### PR DESCRIPTION
When using `httpd.rootRedirect.url` in AEMaaCS, you get one unnecessary 301 redirect:
```
$ curl -IL http://aemaacs.example.com
HTTP/1.0 301 Moved Permanently
Retry-After: 0
Location: https://aemaacs.example.com/  # first SSL upgrade - fine
[...]

HTTP/1.0 200 Connection established

HTTP/2 301
location: http://aemaacs.example.com/demo.html  # this one is unnecessary - we were already on an HTTPS connection
[...]

HTTP/1.0 301 Moved Permanently
Retry-After: 0
Location: https://aemaacs.example.com/demo.html  # final page
[...]

HTTP/2 200
[...]
```

Since there is no possibility to host a non-SSL VHost on AEMaaCS (you can't even add a domain when there's no SSL certificate present that covers it), the redirect to the HTTP version of the VHost is not necessary. The fix in this PR leads to this behaviour:

```
$ curl -IL http://aemaacs.example.com
HTTP/1.0 301 Moved Permanently
Retry-After: 0
Location: https://aemaacs.example.com/  # first SSL upgrade - fine
[...]

HTTP/1.0 200 Connection established

HTTP/1.0 301 Moved Permanently
Retry-After: 0
Location: https://aemaacs.example.com/demo.html  # final page
[...]

HTTP/2 200
[...]
```