### PR TITLE
Role aem-dispatcher-ams: Introduce options to disable utility script generation

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.12.0" date="not released">
+      <action type="add" dev="trichter">
+        Role aem-dispatcher-ams: Introduce utils.deploy.dispatcher.generateScript and utils.deploy.dispatcher.flush.generateScript to control utility script generation.
+      </action>
+    </release>
+
     <release version="1.11.4" date="2021-12-18">
       <action type="update" dev="sseifert">
         Role aem-cms: Do not show warning for uncovered node /etc/replication.

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-ams.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-ams.yaml
@@ -229,12 +229,14 @@ files:
   variants:
   - aem-publish
   template: utils/aem-dispatcher-ams/deploy.sh.hbs
+  condition: ${utils.deploy.dispatcher.generateScript}
 
 - file: flush.sh
   dir: utils/aem-dispatcher-ams
   variants:
     - aem-publish
   template: utils/aem-dispatcher-ams/flush.sh.hbs
+  condition: ${utils.deploy.dispatcher.flush.generateScript}
 
 config:
 
@@ -464,6 +466,9 @@ config:
     deploy:
       dispatcher:
 
+        # controls wether to render deployment utility script
+        generateScript: true
+
         backup:
           # when enabled the current dispatcher configuration is copied to the backup path
           enabled: true
@@ -492,7 +497,11 @@ config:
               options: -rv
 
         # Configuration for dispatcher flush utility script
+
         flush:
+          # controls generation of the dispatcher flush utility script
+          generateScript: true
+
           path:
             # The content in these paths (below ${PUBLISH_DOCROOT} will be deleted when executing the flush script
             - etc

--- a/example/src/main/environments/test.yaml
+++ b/example/src/main/environments/test.yaml
@@ -207,6 +207,19 @@ nodes:
                     dest: /tmp/some-restricted-destination
                     sudo: true
 
+- node: webserver-ams-cloudmanager
+  roles:
+    - role: aem-dispatcher-ams
+      variants:
+        - aem-publish
+      config:
+        utils:
+          deploy:
+            dispatcher:
+              # disable generation of AMS utility scripts because cloudmanager is not using them
+              generateScript: false
+              flush:
+                generateScript: false
 
 config:
   quickstart:


### PR DESCRIPTION
Introduce utils.deploy.dispatcher.generateScript and utils.deploy.dispatcher.flush.generateScript to control utility script generation.