### PR TITLE
Role aem-dispatcher-cloud: Add back symlink of "default.host" which was removed in 1.11.2.

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -30,6 +30,9 @@
       <action type="update" dev="sseifert">
         Role aem-dispatcher-cloud: Synch with default dispatcher configuration from Adobe project archetype 24 to 35.
       </action>
+      <action type="update" dev="sseifert">
+        Role aem-dispatcher-cloud: Add back symlink of "default.host" which was removed in 1.11.2.
+      </action>
       <action type="fix" dev="mrozati" issue="WDCONGA-21">
         Fix sling mappings to avoid generation of reverse mapping for "/". Because it would otherwise match every path that is not caught by sling mappings, even when they are not under a sling mapping root path.
       </action>

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
@@ -263,6 +263,10 @@ files:
   url: classpath:/aem-sdk-dispatcher/src/conf.d/available_vhosts/default.vhost
   variants:
   - aem-publish
+- file: conf.d/enabled_vhosts/9999_default.vhost
+  symlinkTarget: conf.d/available_vhosts/default.vhost
+  variants:
+  - aem-publish
 - file: conf.dispatcher.d/dispatcher.any
   url: classpath:/aem-sdk-dispatcher/src/conf.dispatcher.d/dispatcher.any
   variants:


### PR DESCRIPTION
Explicitly assign a prefix "9999_" in enabled_vhosts to ensure this host is picked last.