### PR TITLE
Role aem-dispatcher: Fix / Enhance remoteip functionality

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,18 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.12.2" date="not released">
+      <action type="add" dev="trichter">
+        Role aem-dispatcher: Add remoteip functionality to author vhosts.
+      </action>
+      <action type="add" dev="trichter">
+        Role aem-dispatcher: Introduce httpd.remoteIPHeader to allow configuration of the header representing the client ip.
+      </action>
+      <action type="fix" dev="trichter">
+        Role aem-dispatcher: Fix not working condition for remoteip module introduced with 1.3.0
+      </action>
+    </release>
+
     <release version="1.12.0" date="2022-03-15">
       <action type="add" dev="nbellack">
         Role aem-dispatcher, aem-dispatcher-ams, aem-dispatcher-cloud: Make log level for mod_rewrite configurable.

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
@@ -331,7 +331,7 @@ config:
       - ^/var
       uriAllowContentAccess:
       - ^/content/dam
-^
+
     # Custom configuration snippets for vhost files (only on publish dispatcher - useful for tenant-specific configurations)
     customVHostConfig:
       # Placed at the top of the vhost config file

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
@@ -331,7 +331,7 @@ config:
       - ^/var
       uriAllowContentAccess:
       - ^/content/dam
-
+^
     # Custom configuration snippets for vhost files (only on publish dispatcher - useful for tenant-specific configurations)
     customVHostConfig:
       # Placed at the top of the vhost config file
@@ -345,6 +345,8 @@ config:
     remoteIPInternalProxies:
     # - 10.0.2.0/24
     # - gateway.localdomain
+    # The name of the header the remoteip module is using for detecting the client IP address
+    remoteIPHeader: X-Forwarded-For
 
   dispatcher:
 

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.partials.hbs
@@ -38,6 +38,17 @@ CustomLog ${APACHE_LOG_DIR}/vhost_author_access.log {{httpd.logging.accessLogFor
 RewriteEngine On
 {{/block}}
 
+{{~#block "remoteIPForwarding"}}
+{{~#if httpd.remoteIPInternalProxies}}
+# Trusted remote ip proxies
+<IfModule mod_remoteip.c>
+{{~#each httpd.remoteIPInternalProxies}}
+RemoteIPInternalProxy {{this}}
+{{~/each}}
+RemoteIPHeader {{httpd.remoteIPHeader}}
+</IfModule>
+{{~/if}}
+{{/block}}
 
 {{~#block "rewriteEnforcePrimaryHostname"}}
 # Make sure primary hostname is always used - but don't rewrite the dispatcher invalidation URL

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.partials.hbs
@@ -54,10 +54,11 @@ RewriteEngine On
 {{~#block "remoteIPForwarding"}}
 {{~#if httpd.remoteIPInternalProxies}}
 # Trusted remote ip proxies
-<IfModule remoteip>
+<IfModule mod_remoteip.c>
 {{~#each httpd.remoteIPInternalProxies}}
 RemoteIPInternalProxy {{this}}
 {{~/each}}
+RemoteIPHeader {{httpd.remoteIPHeader}}
 </IfModule>
 {{~/if}}
 {{/block}}


### PR DESCRIPTION
I noticed that the IfModule statement did not work the way it was designed.
Also the remote ip configuration should be possible in author vhosts (since there a valid client ip is required for several ip secured areas)