### PR TITLE
fix/add disabling of ServerSignature 

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -30,6 +30,12 @@
       <action type="add" dev="trichter">
         Role aem-dispatcher, aem-dispatcher-ams, aem-dispatcher-cloud: Introduce dispatcher.passError to allow configuration of DispatcherPassError parameter.
       </action>
+      <action type="fix" dev="trichter">
+        Role aem-dispatcher: Don't show exact Apache/Dispatcher version in Server footer.
+      </action>
+      <action type="add" dev="trichter">
+        Role aem-dispatcher-ams, aem-dispatcher-cloud: Don't show exact Apache/Dispatcher footer.
+      </action>
     </release>
 
     <release version="1.12.2" date="2022-05-11">

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-ams/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-ams/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -93,6 +93,9 @@ DocumentRoot "${PUBLISH_DOCROOT}"
 
 # Do not allow RFC 2616 trace requests
 TraceEnable Off
+
+# Suppress leaking the exact Apache/Dispatcher version
+ServerSignature Off
 {{/block}}
 
 {{~#block "customVHostConfigBeforeSslEnforce"}}

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -75,6 +75,9 @@ AllowEncodedSlashes NoDecode
 
 # Do not allow RFC 2616 trace requests
 TraceEnable Off
+
+# Suppress leaking the exact Apache/Dispatcher version
+ServerSignature Off
 {{/block}}
 
 

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/author/vhost_author.partials.hbs
@@ -34,6 +34,9 @@ CustomLog ${APACHE_LOG_DIR}/vhost_author_access.log {{httpd.logging.accessLogFor
 
 
 {{~#block "generalSettings"}}
+# Suppress leaking the exact Apache/Dispatcher version
+ServerSignature Off
+
 # Enable rewrite engine
 RewriteEngine On
 {{/block}}

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.partials.hbs
@@ -47,6 +47,9 @@ CustomLog ${APACHE_LOG_DIR}/vhost_publish_{{httpd.serverName}}_access.log {{http
 # Do not allow RFC 2616 trace requests
 TraceEnable Off
 
+# Suppress leaking the exact Apache/Dispatcher version
+ServerSignature Off
+
 # Enable rewrite engine
 RewriteEngine On
 {{/block}}


### PR DESCRIPTION
The solution from #67 was implemented for aem-dispatcher role only. 
Beside that the disabling only worked in our test-setup when the `ServerSignature Off` is in the vhost.

Beside that I have also adopted the solution for the dispatcher roles
* aem-dispatcher-ams
* aem-dispatcher-cloud

cc @bellackn 