### PR TITLE
Introduce httpd.headers.featurePolicy Header

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -25,7 +25,10 @@
 
     <release version="1.12.4" date="not released">
       <action type="add" dev="trichter">
-        Role aem-dispatcher, aem-dispatcher-ams, aem-dispatcher-cloud: Introduce (optional) headers.permissionsPolicy to allow configuration of the Permissions-Policy header.
+        Role aem-dispatcher, aem-dispatcher-ams, aem-dispatcher-cloud: Introduce (optional) httpd.headers.permissionsPolicy to allow configuration of the Permissions-Policy header.
+      </action>
+      <action type="add" dev="trichter">
+        Role aem-dispatcher, aem-dispatcher-ams, aem-dispatcher-cloud: Introduce (optional) httpd.headers.featurePolicy to allow configuration of the Feature-Policy header.
       </action>
       <action type="add" dev="trichter">
         Role aem-dispatcher, aem-dispatcher-ams, aem-dispatcher-cloud: Introduce dispatcher.passError to allow configuration of DispatcherPassError parameter.

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-ams.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-ams.yaml
@@ -277,7 +277,9 @@ config:
     headers:
       # Enables/Configures the Content-Security-Policy header on publish dispatcher (see https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
       contentSecurityPolicy:
-      # Enables/Configures the permissions-poicy header on publish dispatcher (see https://w3c.github.io/webappsec-permissions-policy/)
+      # Enables/Configures the Feature-Policy  header on publish dispatcher (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy)
+      featurePolicy:
+      # Enables/Configures the Permissions-Policy header on publish dispatcher (see https://w3c.github.io/webappsec-permissions-policy/)
       permissionsPolicy:
       # Enables/Configures the Referrer-Policy header on publish dispatcher (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)
       referrerPolicy: "origin-when-cross-origin"

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
@@ -335,7 +335,9 @@ config:
     headers:
       # Enables/Configures the Content-Security-Policy header on publish dispatcher (see https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
       contentSecurityPolicy:
-      # Enables/Configures the permissions-poicy header on publish dispatcher (see https://w3c.github.io/webappsec-permissions-policy/)
+      # Enables/Configures the Feature-Policy  header on publish dispatcher (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy)
+      featurePolicy:
+      # Enables/Configures the Permissions-Policy header on publish dispatcher (see https://w3c.github.io/webappsec-permissions-policy/)
       permissionsPolicy:
       # Enables/Configures the Referrer-Policy header on publish dispatcher (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)
       referrerPolicy: "origin-when-cross-origin"

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
@@ -305,7 +305,9 @@ config:
     headers:
       # Enables/Configures the Content-Security-Policy header on publish dispatcher (see https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
       contentSecurityPolicy:
-      # Enables/Configures the permissions-poicy header on publish dispatcher (see https://w3c.github.io/webappsec-permissions-policy/)
+      # Enables/Configures the Feature-Policy  header on publish dispatcher (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy)
+      featurePolicy:
+      # Enables/Configures the Permissions-Policy header on publish dispatcher (see https://w3c.github.io/webappsec-permissions-policy/)
       permissionsPolicy:
       # Enables/Configures the Referrer-Policy header on publish dispatcher (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)
       referrerPolicy: "origin-when-cross-origin"

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-ams/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-ams/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -181,6 +181,10 @@ Header edit Cache-Control "^$" "public, must-revalidate"
 # Send CSP header to client
 Header set Content-Security-Policy "{{httpd.headers.contentSecurityPolicy}}"
 {{~/if}}
+{{~#if httpd.headers.featurePolicy}}
+# Send feature policy header to client
+Header set Feature-Policy "{{httpd.headers.featurePolicy}}"
+{{~/if}}
 {{~#if httpd.headers.permissionsPolicy}}
 # Send permissions policy header to client
 Header set Permissions-Policy "{{httpd.headers.permissionsPolicy}}"

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -139,6 +139,10 @@ Header set Cache-Control "public, must-revalidate"
 # Send CSP header to client
 Header set Content-Security-Policy "{{httpd.headers.contentSecurityPolicy}}"
 {{~/if}}
+{{~#if httpd.headers.featurePolicy}}
+# Send feature policy header to client
+Header set Feature-Policy "{{httpd.headers.featurePolicy}}"
+{{~/if}}
 {{~#if httpd.headers.permissionsPolicy}}
 # Send permissions policy header to client
 Header set Permissions-Policy "{{httpd.headers.permissionsPolicy}}"

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher/publish/vhost_publish_tenant.partials.hbs
@@ -186,6 +186,10 @@ RewriteRule ^(.*)$ http://{{httpHost httpd.serverName port=httpd.serverPort}}$1 
 # Send CSP header to client
 Header set Content-Security-Policy "{{httpd.headers.contentSecurityPolicy}}"
 {{~/if}}
+{{~#if httpd.headers.featurePolicy}}
+# Send feature policy header to client
+Header set Feature-Policy "{{httpd.headers.featurePolicy}}"
+{{~/if}}
 {{~#if httpd.headers.permissionsPolicy}}
 # Send permissions policy header to client
 Header set Permissions-Policy "{{httpd.headers.permissionsPolicy}}"

--- a/example/src/main/environments/test.yaml
+++ b/example/src/main/environments/test.yaml
@@ -115,6 +115,7 @@ nodes:
           - _merge_
         headers:
           htmlExpirationTimeMin: 3
+          featurePolicy: "geolocation 'self' https://example.com; camera 'none';"
           permissionsPolicy: 'geolocation=(self "https://example.com"), camera=()'
       dispatcher:
         passError: 403,404
@@ -164,6 +165,7 @@ nodes:
               - _merge_
           headers:
             htmlExpirationTimeMin: 6
+            featurePolicy: 'geolocation *;'
             permissionsPolicy: 'geolocation=*'
 
         dispatcher:
@@ -284,6 +286,7 @@ tenants:
       rootRedirect.url: /de.html
       headers:
         contentSecurityPolicy: "script-src 'self' 'unsafe-inline' 'unsafe-eval' *.sample1.com;"
+        featurePolicy: "fullscreen 'none'; geolocation 'none';"
         permissionsPolicy: "fullscreen=(), geolocation=()"
         xssProtection: "1; mode=block"
         referrerPolicy: "strict-origin-when-cross-origin"


### PR DESCRIPTION
This enhances #77 because the Permissions-Policy is currently not supported everywhere and the `Feature-Policy` is the predecessor of the `Permissions-Policy` header.