### PR TITLE
Role aem-dispatcher-ams, aem-dispatcher-cloud fix duplicate X-Frame-Options header

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -39,6 +39,9 @@
       <action type="add" dev="trichter">
         Role aem-dispatcher-ams, aem-dispatcher-cloud: Don't show exact Apache/Dispatcher footer.
       </action>
+      <action type="fix" dev="trichter">
+        Role aem-dispatcher-ams, aem-dispatcher-cloud fix duplicate X-Frame-Options header.
+      </action>
     </release>
 
     <release version="1.12.2" date="2022-05-11">

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-ams/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-ams/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -72,7 +72,7 @@ DocumentRoot "${PUBLISH_DOCROOT}"
   # Make sure proxies don't deliver the wrong content
   Header append Vary User-Agent env=!dont-vary
   # Prevent clickjacking
-  Header always set X-Frame-Options "SAMEORIGIN"
+  Header always set X-Frame-Options SAMEORIGIN
 </Directory>
 <Directory "${PUBLISH_DOCROOT}">
   AllowOverride None

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-ams/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-ams/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -72,7 +72,7 @@ DocumentRoot "${PUBLISH_DOCROOT}"
   # Make sure proxies don't deliver the wrong content
   Header append Vary User-Agent env=!dont-vary
   # Prevent clickjacking
-  Header always append X-Frame-Options SAMEORIGIN
+  Header always set X-Frame-Options "SAMEORIGIN"
 </Directory>
 <Directory "${PUBLISH_DOCROOT}">
   AllowOverride None

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -60,7 +60,7 @@ AllowEncodedSlashes NoDecode
   # Don't compress images & videos
   SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png|webm|mp4)$ no-gzip dont-vary
   # Prevent clickjacking
-  Header always append X-Frame-Options SAMEORIGIN
+  Header always set X-Frame-Options SAMEORIGIN
 </Directory>
 <IfModule disp_apache2.c>
   # Enabled to allow rewrites to take affect and not be ignored by the dispatcher module


### PR DESCRIPTION
With the current solution we are sending duplicate headers when for example `sling.additional.response.headers` is configured to send X-Frame-Options.
Since `setifempty` is only possible with httpd/apache 2.4.7+ I decided to just overwrite the header with our desired value.