### PR TITLE
Revert dispatcher.filter filter list to values from 1.13.0

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,8 +24,8 @@
   <body>
 
     <release version="1.15.0" date="not released">
-      <action type="fix" dev="trichter">
-        Role aem-dispatcher, aem-dispatcher-ams, aem-dispatcher-cloud: Revert dispatcher.filter filter list to values from 1.13.0
+      <action type="fix" dev="trichter" issue="85">
+        Role aem-dispatcher, aem-dispatcher-ams, aem-dispatcher-cloud: Revert #83, move "security-related" deny rules back to dispatcher.filter.
       </action>
     </release>
 

--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.15.0" date="not released">
+      <action type="fix" dev="trichter">
+        Role aem-dispatcher, aem-dispatcher-ams, aem-dispatcher-cloud: Revert dispatcher.filter filter list to values from 1.13.0
+      </action>
+    </release>
+
     <release version="1.14.0" date="2023-01-12">
       <action type="add" dev="trichter">
         Role aem-dispatcher, aem-dispatcher-ams, aem-dispatcher-cloud: Introduce dispatcher.filterAppend filter list.

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-ams.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-ams.yaml
@@ -75,12 +75,6 @@ variants:
       - url: /libs/cq/personalization(/.*)?
         method: "GET"
         type: allow
-      # Allow current user [from default_filters.any]
-      - url: /libs/granite/security/currentuser.json
-        type: allow
-
-      # list of filters that will be appended after the "normal" filter list to ensure denied content is not accidentally allowed again by other selectors
-      filterAppend:
       # Deny content grabbing for greedy queries and prevent un-intended self DOS attacks [from default_filters.any]
       - selectors: (feed|rss|pages|languages|blueprint|infinity|tidy|sysview|docview|query|[0-9-]+|jcr:content)
         extension: (json|xml|html|feed)
@@ -90,6 +84,9 @@ variants:
         type: deny
       - query: wcmmode=.*
         type: deny
+      # Allow current user [from default_filters.any]
+      - url: /libs/granite/security/currentuser.json
+        type: allow
       # Deny content grabbing for /content - additional selectors not included in default dispatcher.any
       - path: /content(/.*)?
         selectors: (ambits|assetsearch|assignments|childrenlist|cloudservices|contentfinder|context|emailservice|exacttarget|ext|form|media|missingpages|mobileapps|pages|paragraphs|payloadsummary|permissions|publications|referencelist|savedsearch|skippedpages|search|social|style|tags|tagtree|timezones)
@@ -106,6 +103,9 @@ variants:
       - path: /content(/.*)?
         selectors: (overlay)
         type: deny
+
+      # list of filters that will be appended after the "normal" filter list to ensure denied content is not accidentally allowed again by other selectors
+      filterAppend:
       # block form validator bypass
       - url: '/.*'
         selectors: "(form)"

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
@@ -78,6 +78,15 @@ variants:
       - url: /libs/cq/personalization(/.*)?
         method: GET
         type: allow
+      # Deny content grabbing for greedy queries and prevent un-intended self DOS attacks [from default_filters.any]
+      - selectors: (feed|rss|pages|languages|blueprint|infinity|tidy|sysview|docview|query|[0-9-]+|jcr:content)
+        extension: (json|xml|html|feed)
+        type: deny
+      # Deny authoring query params [from default_filters.any]
+      - query: debug=.*
+        type: deny
+      - query: wcmmode=.*
+        type: deny
       # Allow current user [from default_filters.any]
       - url: /libs/granite/security/currentuser.json
         type: allow
@@ -96,18 +105,6 @@ variants:
       - url: /graphql/execute.json*
         method: (GET|POST|OPTIONS)
         type: allow
-
-      # list of filters that will be appended after the "normal" filter list to ensure denied content is not accidentally allowed again by other selectors
-      filterAppend:
-      # Deny content grabbing for greedy queries and prevent un-intended self DOS attacks [from default_filters.any]
-      - selectors: (feed|rss|pages|languages|blueprint|infinity|tidy|sysview|docview|query|[0-9-]+|jcr:content)
-        extension: (json|xml|html|feed)
-        type: deny
-      # Deny authoring query params [from default_filters.any]
-      - query: debug=.*
-        type: deny
-      - query: wcmmode=.*
-        type: deny
       # Deny content grabbing for /content - additional selectors not included in default dispatcher.any
       - path: /content(/.*)?
         selectors: (ambits|assetsearch|assignments|childrenlist|cloudservices|contentfinder|context|emailservice|exacttarget|ext|form|media|missingpages|mobileapps|pages|paragraphs|payloadsummary|permissions|publications|referencelist|savedsearch|skippedpages|search|social|style|tags|tagtree|timezones)
@@ -124,6 +121,9 @@ variants:
       - path: /content(/.*)?
         selectors: (overlay)
         type: deny
+
+      # list of filters that will be appended after the "normal" filter list to ensure denied content is not accidentally allowed again by other selectors
+      filterAppend:
       # block form validator bypass
       - url: '/.*'
         selectors: "(form)"

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
@@ -53,15 +53,6 @@ variants:
       # Enable features [from default dispatcher.any]
       - url: /libs/cq/personalization(/.*)?
         type: allow
-      # Allow access to client libraries and designs at /etc
-      - url: (/etc/clientlibs|/etc.clientlibs|/etc/designs/.*/clientlibs)(/.*)?
-        type: allow
-      # open consoles (access is controlled in httpd config)
-      - url: /(admin|crx|system)(/.*)?
-        type: allow
-
-      # list of filters that will be appended after the "normal" filter list to ensure denied content is not accidentally allowed again by other selectors
-      filterAppend:
       # Deny content grabbing, on all accessible pages [from default dispatcher.any]
       - selectors: ((sys|doc)view|query|[0-9-]+)
         extension: (json|xml)
@@ -87,6 +78,15 @@ variants:
       - path: /content(/.*)?
         selectors: (overlay)
         type: deny
+      # Allow access to client libraries and designs at /etc
+      - url: (/etc/clientlibs|/etc.clientlibs|/etc/designs/.*/clientlibs)(/.*)?
+        type: allow
+      # open consoles (access is controlled in httpd config)
+      - url: /(admin|crx|system)(/.*)?
+        type: allow
+
+      # list of filters that will be appended after the "normal" filter list to ensure denied content is not accidentally allowed again by other selectors
+      filterAppend:
       # block form validator bypass
       - url: '/.*'
         selectors: "(form)"


### PR DESCRIPTION
With #83 we moved deny rules to the new `dispatcher.filterAppend` list in order to implement a solution for blocking the form validator bypass issue with #84.

The problem with that solution is that it forces the users of the conga-aem-definitions to reallow for example form posts in the `filterAppend` which then also would make it necessary to readd the fix for the form validator bypass at the end of the customized `filterAppend` list.

From my perspective it makes more sense to only add the fix for the validator bypass to the filterAppend list and keep the other filters as they are. 