### PR TITLE
Role aem-dispatcher-cloud: Introduce httpd.generateAvailableVhost and httpd.generateEnabledVhost to control vhost generation.

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="1.15.0" date="not released">
+      <action type="add" dev="trichter" issue="86">
+        Role aem-dispatcher-cloud: Introduce httpd.generateAvailableVhost and httpd.generateEnabledVhost to control vhost generation.
+      </action>
       <action type="fix" dev="trichter" issue="85">
         Role aem-dispatcher, aem-dispatcher-ams, aem-dispatcher-cloud: Revert #83, move "security-related" deny rules back to dispatcher.filter.
       </action>

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
@@ -169,6 +169,7 @@ files:
   template: conf.d/available_vhosts/tenant.vhost.hbs
   multiply: tenant
   fileHeader: conf
+  condition: ${httpd.generateAvailableVhost}
 
 # enabled vhosts
 - file: ${new('java.text.DecimalFormat','0000').format(multiplyIndex)}_${tenant}.vhost
@@ -177,6 +178,7 @@ files:
   variants:
   - aem-publish
   multiply: tenant
+  condition: ${httpd.generateEnabledVhost}
 
 # global rewrite rules
 - file: rewrite.rules
@@ -384,6 +386,12 @@ config:
       beforeRewrite:
       # Placed at the bottom of the vhost confign file
       after:
+
+    # Controls the generation of available_vhosts files
+    generateAvailableVhost: true
+
+    # Controls the generation of enabled_vhosts files
+    generateEnabledVhost: true
 
     # Allows to define different server names/alias names per environment in a single dispatcher configuration
     #cloudManagerConditional:

--- a/example/src/main/environments/test.yaml
+++ b/example/src/main/environments/test.yaml
@@ -315,6 +315,8 @@ tenants:
 - tenant: cloud-sample4.com
   config:
     httpd:
+      generateEnabledVhost: false
+      generateAvailableVhost: false
       cloudManagerConditional:
         dev:
           serverName: www.dev-sample4.com


### PR DESCRIPTION
With #58 we introduced the aem-dispatcher-ams role and this PR ports the functionality to disable the available and enabled vhost.