### PR TITLE
Role aem-dispatcher-cloud: Introduce httpd.rewriteIncludes

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="1.15.0" date="not released">
+      <action type="fix" dev="trichter" issue="87">
+        Role aem-dispatcher-cloud: Introduce httpd.rewriteIncludes (ported from aem-dispatcher-ams role).
+      </action>
       <action type="fix" dev="trichter" issue="85">
         Role aem-dispatcher, aem-dispatcher-ams, aem-dispatcher-cloud: Revert #83, move "security-related" deny rules back to dispatcher.filter.
       </action>

--- a/changes.xml
+++ b/changes.xml
@@ -24,7 +24,7 @@
   <body>
 
     <release version="1.15.0" date="not released">
-      <action type="fix" dev="trichter" issue="87">
+      <action type="add" dev="trichter" issue="87">
         Role aem-dispatcher-cloud: Introduce httpd.rewriteIncludes (ported from aem-dispatcher-ams role).
       </action>
       <action type="fix" dev="trichter" issue="85">

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
@@ -357,6 +357,10 @@ config:
       # Set the default experiation time for text/html responses (enabled by default in AEM Cloud Service webserver)
       htmlExpirationTimeMin: 5
 
+    # List of rewrite rules to include in the vhost
+    rewriteIncludes:
+      - conf.d/rewrites/rewrite.rules
+
     # Request URI patterns for Sling maping short URL configuration
     mapping:
       uriExcludeFromMapping:

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -73,7 +73,9 @@ AllowEncodedSlashes NoDecode
 </IfModule>
 <IfModule mod_rewrite.c>
   RewriteEngine  on
-  Include conf.d/rewrites/rewrite.rules
+  {{~#each httpd.rewriteIncludes}}
+    Include {{ this }}
+  {{~/each}}
 </IfModule>
 
 # Do not allow RFC 2616 trace requests

--- a/example/src/main/environments/test.yaml
+++ b/example/src/main/environments/test.yaml
@@ -326,6 +326,9 @@ tenants:
         prod:
           serverName: www.prod-sample4.com
       rootRedirect.url: /content/sample4/en.html
+      rewriteIncludes:
+        - _merge_
+        - conf.d/rewrites/additional_rewrite.rules
 
 - tenant: ams-sample5.com
   config:


### PR DESCRIPTION
This PR ports the `httpd.rewriteIncludes` from the aem-dispatcher-ams role (added with #58) to the aem-dispatcher-cloud role
