### PR TITLE
Introduce httpd.headers.htmlExpirationTimeSec as replacement of httpd.headers.htmlExpirationTimeMin

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -28,7 +28,7 @@
         Role aem-dispatcher-cloud: Add httpd.headers.htmlExpirationTimeSec parameter to control the default expiration time for text/html responses.
       </action>
       <action type="remove" dev="sseifert">
-        Role aem-dispatcher-cloud: Remove httpd.headers.htmlExpirationTimeMin parameter which was interperted incorrectly as seconds instead of minutes. Build will fail if this parameters is still in use.
+        Role aem-dispatcher-cloud: Remove httpd.headers.htmlExpirationTimeMin parameter which was interpreted incorrectly as seconds instead of minutes. Build will fail if this parameters is still in use.
       </action>
     </release>
 

--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,15 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="2.0.0" date="not released">
+      <action type="add" dev="sseifert">
+        Role aem-dispatcher-cloud: Add httpd.headers.htmlExpirationTimeSec parameter to control the default expiration time for text/html responses.
+      </action>
+      <action type="remove" dev="sseifert">
+        Role aem-dispatcher-cloud: Remove httpd.headers.htmlExpirationTimeMin parameter which was interperted incorrectly as seconds instead of minutes. Build will fail if this parameters is still in use.
+      </action>
+    </release>
+
     <release version="1.15.0" date="2023-03-17">
       <action type="add" dev="trichter" issue="88">
         Role aem-dispatcher-cloud: Introduce httpd.rewrites (ported from aem-dispatcher-ams role).

--- a/conga-aem-definitions/pom.xml
+++ b/conga-aem-definitions/pom.xml
@@ -25,13 +25,13 @@
   <parent>
     <groupId>io.wcm.devops.conga.definitions</groupId>
     <artifactId>io.wcm.devops.conga.definitions.aem.parent</artifactId>
-    <version>1.15.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
   <groupId>io.wcm.devops.conga.definitions</groupId>
   <artifactId>io.wcm.devops.conga.definitions.aem</artifactId>
-  <version>1.15.1-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>config-definition</packaging>
 
   <name>CONGA AEM Definitions</name>

--- a/conga-aem-definitions/pom.xml
+++ b/conga-aem-definitions/pom.xml
@@ -51,7 +51,7 @@
       <plugin>
         <groupId>io.wcm.devops.conga</groupId>
         <artifactId>conga-maven-plugin</artifactId>
-        <version>1.14.6</version>
+        <version>1.16.0-SNAPSHOT</version>
         <extensions>true</extensions>
         <dependencies>
 
@@ -59,12 +59,12 @@
           <dependency>
             <groupId>io.wcm.devops.conga.plugins</groupId>
             <artifactId>io.wcm.devops.conga.plugins.sling</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.2</version>
           </dependency>
           <dependency>
             <groupId>io.wcm.devops.conga.plugins</groupId>
             <artifactId>io.wcm.devops.conga.plugins.aem</artifactId>
-            <version>2.16.0</version>
+            <version>2.19.4</version>
           </dependency>
 
         </dependencies>

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-ams.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-ams.yaml
@@ -298,8 +298,6 @@ config:
         # Cache AEM Clientlibs with long cache key for 1 year
         - locationMatch: "\\.lc-.*-lc\\.min\\.(css|js)$"
           directives: "max-age=31536000, public"
-      # Set the default experiation time for text/html responses (enabled by default in AEM Cloud Service webserver)
-      htmlExpirationTimeMin: 5
 
     # List of rewrite rules to include in the vhost
     rewriteIncludes:
@@ -382,7 +380,6 @@ config:
     #    serverAliasNames:
     #    - www.dev-alias3a.com
     #    - www.dev-alias3b.com
-    #    htmlExpirationTimeMin: 3
 
 
   dispatcher:

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
@@ -357,7 +357,7 @@ config:
         - locationMatch: "\\.lc-.*-lc\\.min\\.(css|js)$"
           directives: "max-age=31536000, public"
       # Set the default experiation time for text/html responses (enabled by default in AEM Cloud Service webserver)
-      htmlExpirationTimeMin: 5
+      htmlExpirationTimeSec: 300
 
     # List of rewrite rules to include in the vhost
     rewriteIncludes:
@@ -411,7 +411,7 @@ config:
     #    serverAliasNames:
     #    - www.dev-alias3a.com
     #    - www.dev-alias3b.com
-    #    htmlExpirationTimeMin: 3
+    #    htmlExpirationTimeSec: 180
 
 
   dispatcher:

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/variables/global.vars.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/variables/global.vars.hbs
@@ -1,3 +1,6 @@
+{{disallowProperty
+    "httpd.headers.htmlExpirationTimeMin" "Parameter 'httpd.headers.htmlExpirationTimeMin' is no longer supported, please use 'httpd.headers.htmlExpirationTimeSec' instead."
+~}}
 #
 # This file contains the variables defined for all virtual hosts
 #
@@ -34,5 +37,5 @@ Define REWRITE_LOG_LEVEL {{httpd.logging.rewriteLogLevel}}
 
 {{#httpdCloudManagerConditional}}
 # Set the default expiration time for text/html responses (in minutes)
-Define EXPIRATION_TIME {{httpd.headers.htmlExpirationTimeMin}}
+Define EXPIRATION_TIME {{httpd.headers.htmlExpirationTimeSec}}
 {{/httpdCloudManagerConditional}}

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/variables/global.vars.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/variables/global.vars.hbs
@@ -36,6 +36,6 @@ Define REWRITE_LOG_LEVEL {{httpd.logging.rewriteLogLevel}}
 
 
 {{#httpdCloudManagerConditional}}
-# Set the default expiration time for text/html responses (in minutes)
+# Set the default expiration time for text/html responses (in seconds)
 Define EXPIRATION_TIME {{httpd.headers.htmlExpirationTimeSec}}
 {{/httpdCloudManagerConditional}}

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -55,7 +55,7 @@
       <plugin>
         <groupId>io.wcm.devops.conga</groupId>
         <artifactId>conga-maven-plugin</artifactId>
-        <version>1.14.6</version>
+        <version>1.16.0-SNAPSHOT</version>
         <extensions>true</extensions>
         <dependencies>
 
@@ -63,19 +63,19 @@
           <dependency>
             <groupId>io.wcm.devops.conga.plugins</groupId>
             <artifactId>io.wcm.devops.conga.plugins.sling</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.2</version>
           </dependency>
           <dependency>
             <groupId>io.wcm.devops.conga.plugins</groupId>
             <artifactId>io.wcm.devops.conga.plugins.aem</artifactId>
-            <version>2.16.0</version>
+            <version>2.19.4</version>
           </dependency>
 
           <!-- Test with ansible encryption -->
           <dependency>
             <groupId>io.wcm.devops.conga.plugins</groupId>
             <artifactId>io.wcm.devops.conga.plugins.ansible</artifactId>
-            <version>1.3.0</version>
+            <version>1.4.2</version>
           </dependency>
 
         </dependencies>
@@ -93,7 +93,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
         <executions>
           <execution>
             <id>set-properties</id>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -32,7 +32,7 @@
   <groupId>io.wcm.devops.conga.definitions</groupId>
   <artifactId>io.wcm.devops.conga.definitions.aem.example</artifactId>
   <packaging>config</packaging>
-  <version>1.15.1-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
 
   <name>CONGA AEM Definitions Example</name>
   <description>Example environment definition.</description>
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>io.wcm.devops.conga.definitions</groupId>
       <artifactId>io.wcm.devops.conga.definitions.aem</artifactId>
-      <version>1.15.1-SNAPSHOT</version>
+      <version>2.0.0-SNAPSHOT</version>
     </dependency>
 
   </dependencies>

--- a/example/src/main/environments/test.yaml
+++ b/example/src/main/environments/test.yaml
@@ -114,7 +114,7 @@ nodes:
             type: allow
           - _merge_
         headers:
-          htmlExpirationTimeMin: 3
+          htmlExpirationTimeSec: 180
           featurePolicy: "geolocation 'self' https://example.com; camera 'none';"
           permissionsPolicy: 'geolocation=(self "https://example.com"), camera=()'
       dispatcher:
@@ -164,7 +164,6 @@ nodes:
                 type: allow
               - _merge_
           headers:
-            htmlExpirationTimeMin: 6
             featurePolicy: 'geolocation *;'
             permissionsPolicy: 'geolocation=*'
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>io.wcm.devops.conga.definitions</groupId>
   <artifactId>io.wcm.devops.conga.definitions.aem.parent</artifactId>
-  <version>1.15.1-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>CONGA AEM Definitions</name>

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>io.wcm.devops.conga.definitions</groupId>
     <artifactId>io.wcm.devops.conga.definitions.aem.parent</artifactId>
-    <version>1.15.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 
   <groupId>io.wcm.devops.conga.definitions</groupId>
   <artifactId>io.wcm.devops.conga.definitions.aem.root</artifactId>
-  <version>1.15.1-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>CONGA AEM Definitions</name>


### PR DESCRIPTION
* Role `aem-dispatcher-cloud`: Add `httpd.headers.htmlExpirationTimeSec` parameter to control the default expiration time for text/html responses.
* Role `aem-dispatcher-cloud`: Remove `httpd.headers.htmlExpirationTimeMin` parameter which was interpreted incorrectly as seconds instead of minutes. Build will fail if this parameters is still in use.
* also remove `httpd.headers.htmlExpirationTimeMin` from role `aem-dispatcher-ams` which was never used.

Depends on https://github.com/wcm-io-devops/conga/pull/33