### PR TITLE
Role aem-dispatcher-cloud: Use https in rewriteHomepageRedirect

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="2.1.0" date="not released">
+      <action type="fix" dev="trichter">
+        Role aem-dispatcher-cloud: Use https in rewriteHomepageRedirect to avoid unnecessary http redirect.
+      </action>
+    </release>
+
     <release version="2.0.0" date="2023-07-03">
       <action type="add" dev="sseifert">
         Role aem-dispatcher-cloud: Add httpd.headers.htmlExpirationTimeSec parameter to control the default expiration time for text/html responses.

--- a/changes.xml
+++ b/changes.xml
@@ -24,7 +24,7 @@
   <body>
 
     <release version="2.1.0" date="not released">
-      <action type="fix" dev="trichter">
+      <action type="fix" dev="trichter" issue="90">
         Role aem-dispatcher-cloud: Use https in rewriteHomepageRedirect to avoid unnecessary http redirect.
       </action>
     </release>

--- a/changes.xml
+++ b/changes.xml
@@ -23,7 +23,7 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
-    <release version="2.1.0" date="not released">
+    <release version="2.0.2" date="not released">
       <action type="fix" dev="trichter" issue="90">
         Role aem-dispatcher-cloud: Use https in rewriteHomepageRedirect to avoid unnecessary http redirect.
       </action>

--- a/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
+++ b/conga-aem-definitions/src/main/templates/aem-dispatcher-cloud/conf.d/available_vhosts/tenant.vhost.partials.hbs
@@ -214,7 +214,7 @@ RewriteRule ^/(.+)$ /content/$1 [PT,L]
 {{~#block "rewriteHomepageRedirect"}}
 {{~#if httpd.rootRedirect.url}}
 # Root redirect to homepage
-RewriteRule ^/$ {{httpd.rootRedirect.url}} [R={{httpd.rootRedirect.httpStatus}},L]
+RewriteRule ^/$ https://%{HTTP_HOST}{{httpd.rootRedirect.url}} [R={{httpd.rootRedirect.httpStatus}},L]
 {{/if ~}}
 {{/block}}
 


### PR DESCRIPTION
When not specifying the protocol there will be an unnecessary redirect to http first before upgrading again to https.
This happens because the dispatcher is serving requests using http.