### PR TITLE
Role aem-cms: Mark all content packages that might be generated with dependencyChainIgnore=true

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -25,7 +25,7 @@
   <body>
 
     <release version="2.0.10" date="not released">
-      <action type="update" dev="sseifert">
+      <action type="update" dev="sseifert" issue="110">
         Role aem-cms: Mark all content packages that might be generated with dependencyChainIgnore=true - the order of installation is not relevant for those packages.
       </action>
     </release>

--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="2.0.10" date="not released">
+      <action type="update" dev="sseifert">
+        Role aem-cms: Mark all content packages that might be generated with dependencyChainIgnore=true - the order of installation is not relevant for those packages.
+      </action>
+    </release>
+
     <release version="2.0.8" date="2025-02-19">
       <action type="update" dev="sseifert" issue="94">
         Role aem-dispatcher-cloud: Sync with default dispatcher configuration from Adobe AEM project archetype 48 to 51.

--- a/conga-aem-definitions/pom.xml
+++ b/conga-aem-definitions/pom.xml
@@ -51,7 +51,7 @@
       <plugin>
         <groupId>io.wcm.devops.conga</groupId>
         <artifactId>conga-maven-plugin</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3-SNAPSHOT</version>
         <extensions>true</extensions>
         <dependencies>
 
@@ -64,7 +64,7 @@
           <dependency>
             <groupId>io.wcm.devops.conga.plugins</groupId>
             <artifactId>io.wcm.devops.conga.plugins.aem</artifactId>
-            <version>2.20.2</version>
+            <version>2.20.3-SNAPSHOT</version>
           </dependency>
 
         </dependencies>

--- a/conga-aem-definitions/src/main/roles/aem-cms.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-cms.yaml
@@ -30,6 +30,7 @@ files:
   postProcessors:
   - aem-contentpackage
   postProcessorOptions:
+    dependencyChainIgnore: true
     contentPackage:
       name: aem-cms-publish-slingmapping
       packageType: content
@@ -58,6 +59,7 @@ files:
   postProcessors:
   - aem-contentpackage
   postProcessorOptions:
+    dependencyChainIgnore: true
     contentPackage:
       name: aem-cms-author-replicationagents
       packageType: content
@@ -85,6 +87,7 @@ files:
   postProcessors:
   - aem-contentpackage
   postProcessorOptions:
+    dependencyChainIgnore: true
     contentPackage:
       name: aem-cms-publish-replicationagents
       packageType: content
@@ -109,6 +112,7 @@ files:
   postProcessors:
   - aem-contentpackage-osgiconfig
   postProcessorOptions:
+    dependencyChainIgnore: true
     contentPackage:
       name: aem-cms-system-config
       rootPath: /apps/aem-cms-system-config/config

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -56,7 +56,7 @@
       <plugin>
         <groupId>io.wcm.devops.conga</groupId>
         <artifactId>conga-maven-plugin</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.3-SNAPSHOT</version>
         <extensions>true</extensions>
         <dependencies>
 
@@ -69,7 +69,7 @@
           <dependency>
             <groupId>io.wcm.devops.conga.plugins</groupId>
             <artifactId>io.wcm.devops.conga.plugins.aem</artifactId>
-            <version>2.20.2</version>
+            <version>2.20.3-SNAPSHOT</version>
           </dependency>
 
           <!-- Test with ansible encryption -->


### PR DESCRIPTION
the order of installation is not relevant for those packages

depends on https://github.com/wcm-io-devops/conga-aem-plugin/pull/179