### PR TITLE
Role aem-dispatcher-cloud, aem-dispatcher-ams, aem-dispatcher: Add /etc.clientlibs/ as default member of uriExcludeFromMapping

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="2.1.4" date="not released">
+      <action type="fix" dev="sseifert">
+        Role aem-dispatcher-cloud, aem-dispatcher-ams, aem-dispatcher: Add /etc.clientlibs/ as default member of uriExcludeFromMapping.
+      </action>
+    </release>
+
     <release version="2.1.2" date="2026-03-16">
       <action type="fix" dev="trichter" issue="138">
         Role aem-dispatcher-cloud, aem-dispatcher-ams, aem-dispatcher: adjust uriExcludeFromMapping to exclude path segments not substrings.

--- a/changes.xml
+++ b/changes.xml
@@ -25,7 +25,7 @@
   <body>
 
     <release version="2.1.4" date="not released">
-      <action type="fix" dev="sseifert">
+      <action type="fix" dev="sseifert" issue="139">
         Role aem-dispatcher-cloud, aem-dispatcher-ams, aem-dispatcher: Add /etc.clientlibs/ as default member of uriExcludeFromMapping.
       </action>
     </release>

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-ams.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-ams.yaml
@@ -344,6 +344,7 @@ config:
       - ^/dispatcher/invalidate.cache
       - ^/crx/
       - ^/etc/
+      - ^/etc.clientlibs/
       - ^/home/
       - ^/libs/
       - ^/system/

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher-cloud.yaml
@@ -414,6 +414,7 @@ config:
       - ^/dispatcher/invalidate.cache
       - ^/crx/
       - ^/etc/
+      - ^/etc.clientlibs/
       - ^/home/
       - ^/libs/
       - ^/saml_login

--- a/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
+++ b/conga-aem-definitions/src/main/roles/aem-dispatcher.yaml
@@ -335,6 +335,7 @@ config:
       - ^/content/
       - ^/dispatcher/invalidate.cache
       - ^/etc/
+      - ^/etc.clientlibs/
       - ^/home/
       - ^/libs/
       - ^/services/


### PR DESCRIPTION
This fixes a regression introduced with #138
before that change any path starting with `/etc` was excluded from mapping - allowing `/etc.clientlibs` as well.
the fix from #138 changed this to `/etc/`, so we have to include `/etc.clientlibs/` explicitly.